### PR TITLE
ci: play acceptance tests only with slash command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ permissions:
 
 jobs:
   # Ensure project builds before running testing matrix
-  build:
-    name: Build
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -35,6 +35,7 @@ jobs:
           version: latest
 
   generate:
+    name: Generate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -47,36 +48,4 @@ jobs:
         run: |
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
-
-  # Run acceptance tests in a matrix with Terraform CLI versions
-  test:
-    name: Terraform Provider Acceptance Tests
-    needs: build
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
-    steps:
-      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
-        with:
-          terraform_version: ${{ matrix.terraform }}
-          terraform_wrapper: false
-      - run: go mod download
-      - env:
-          TF_ACC: "1"
-          CLOUDAVENUE_ORG: ${{ secrets.CLOUDAVENUE_ORG }}
-          CLOUDAVENUE_USER: ${{ secrets.CLOUDAVENUE_USER }}
-          CLOUDAVENUE_PASSWORD: ${{ secrets.CLOUDAVENUE_PASSWORD }}
-        run: go test -v -cover ./internal/provider/
-        timeout-minutes: 10
+            

--- a/.github/workflows/testacc.yml
+++ b/.github/workflows/testacc.yml
@@ -1,0 +1,63 @@
+Name: Acceptance Tests
+
+on: issue_comment
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+    if: github.event.issue.author_association == 'OWNER' &&
+      github.event.issue.author_association == 'MEMBER' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/testacc')
+    steps:
+    - name: Extract Command
+      id: command
+      uses: xt0rted/slash-command-action@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        command: testacc
+        reaction: "true"
+        reaction-type: "rocket"
+        allow-edits: "false"
+        permission-level: write
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+    - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+    - run: go mod download
+    - run: go build -v .
+
+  test:
+    name: Terraform Provider Acceptance Tests
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # list whatever Terraform versions here you would like to support
+        terraform:
+          - '1.0.*'
+          - '1.1.*'
+          - '1.2.*'
+          - '1.3.*'
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+      - run: go mod download
+      - env:
+          TF_ACC: "1"
+          CLOUDAVENUE_ORG: ${{ secrets.CLOUDAVENUE_ORG }}
+          CLOUDAVENUE_USER: ${{ secrets.CLOUDAVENUE_USER }}
+          CLOUDAVENUE_PASSWORD: ${{ secrets.CLOUDAVENUE_PASSWORD }}
+        run: go test -v -cover ./internal/provider/
+        timeout-minutes: 10


### PR DESCRIPTION
This PR to make a special workflow for acceptance tests.

It require a slash-command in a comment : /testacc

Acceptance Tests are played only if a OWNER or MEMBER comment the PR with this slash-command.