### PR TITLE
chore(helper): add helper stringpm `Default` (#55)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.19
 
 require (
 	github.com/antihax/optional v1.0.0
+	github.com/dchest/uniuri v1.2.0
+	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.1.1
@@ -28,7 +30,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.14.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/uniuri v1.2.0 h1:koIcOUdrTIivZgSLhHQvKgqdWZq5d7KdMEWF1Ud6+5g=
+github.com/dchest/uniuri v1.2.0/go.mod h1:fSzm4SLHzNZvWLvWJew423PhAzkpNQYq+uNLq4kxhkY=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=

--- a/internal/helpers/stringpm/README.md
+++ b/internal/helpers/stringpm/README.md
@@ -1,0 +1,23 @@
+# CloudAvenue Plan Modifier String Helper
+
+This helper is used to modify a string value in a plan.
+
+## Helpers Available
+
+### `Default`
+
+This helper is used to set a default value for a string.
+
+```go
+// Schema defines the schema for the resource.
+func (r *vappResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "name": schema.StringAttribute{
+                Required:            true,
+                MarkdownDescription: "A name for ...",
+                PlanModifiers: []planmodifier.String{
+                    stringpm.Default("default-name"),
+                },
+            },
+```

--- a/internal/helpers/stringpm/default.go
+++ b/internal/helpers/stringpm/default.go
@@ -1,0 +1,42 @@
+package stringpm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func Default(str string) planmodifier.String {
+	return &defaultPlanModifier{str}
+}
+
+type defaultPlanModifier struct {
+	value string
+}
+
+var _ planmodifier.String = (*defaultPlanModifier)(nil)
+
+func (str *defaultPlanModifier) Description(ctx context.Context) string {
+	return fmt.Sprintf("Default value: %s", str)
+}
+
+func (str *defaultPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return fmt.Sprintf("Default value: `%s`", str)
+}
+
+func (str *defaultPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// If the attribute configuration is not null, we are done here
+	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// If the attribute plan is "known" and "not null", then a previous plan modifier in the sequence
+	// has already been applied, and we don't want to interfere.
+	if !req.PlanValue.IsUnknown() && !req.PlanValue.IsNull() {
+		return
+	}
+
+	resp.PlanValue = types.StringValue(str.value)
+}

--- a/internal/helpers/stringpm/default_test.go
+++ b/internal/helpers/stringpm/default_test.go
@@ -1,0 +1,97 @@
+package stringpm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dchest/uniuri"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/stringpm"
+)
+
+func TestDefaultModifierPlanModifyString(t *testing.T) {
+	expectedValue := uniuri.New()
+
+	testCases := map[string]struct {
+		request  planmodifier.StringRequest
+		expected *planmodifier.StringResponse
+	}{
+		"null-state": {
+			// when we first create the resource, use the unknown
+			// value
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringNull(),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringNull(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringValue(expectedValue),
+			},
+		},
+		"known-plan": {
+			// this would really only happen if we had a plan
+			// modifier setting the value before this plan modifier
+			// got to it
+			//
+			// but we still want to preserve that value, in this
+			// case
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue("other"),
+				PlanValue:   types.StringValue("test"),
+				ConfigValue: types.StringNull(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringValue("test"),
+			},
+		},
+		"non-null-state-unknown-plan": {
+			// this is the situation we want to preserve the state
+			// in
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue("test"),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringNull(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringValue(expectedValue),
+			},
+		},
+		"unknown-config": {
+			// this is the situation in which a user is
+			// interpolating into a field. We want that to still
+			// show up as unknown, otherwise they'll get apply-time
+			// errors for changing the value even though we knew it
+			// was legitimately possible for it to change and the
+			// provider can't prevent this from happening
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue("test"),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringUnknown(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringValue(expectedValue),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			// t.Parallel()
+
+			resp := &planmodifier.StringResponse{
+				PlanValue: testCase.request.PlanValue,
+			}
+
+			stringpm.Default(expectedValue).PlanModifyString(context.Background(), testCase.request, resp)
+
+			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION

### Description of your changes

Close #55

### How has this code been tested

```
ok  	github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/stringpm	0.413s
```
