### PR TITLE
feat(vdc): change block to attribute

### DIFF
--- a/docs/data-sources/vdc.md
+++ b/docs/data-sources/vdc.md
@@ -45,12 +45,12 @@ It must be at least 1200.
 It must be between 1 and 5000.
 - `service_class` (String) The service class of the org VDC. It can be `ECO`, `STD`, `HP` or `VOIP`.
 - `storage_billing_model` (String) Choose Billing model of storage resources. It can be `PAYG` or `RESERVED`.
-- `storage_profile` (Block List) List of storage profiles for this VDC. (see [below for nested schema](#nestedblock--storage_profile))
+- `storage_profiles` (Attributes List) List of storage profiles for this VDC. (see [below for nested schema](#nestedatt--storage_profiles))
 - `vdc_group` (String) Name of an existing VDC group or a new one. This allows you to isolate your VDC.
 VMs of VDCs which belong to the same VDC group can communicate together.
 
-<a id="nestedblock--storage_profile"></a>
-### Nested Schema for `storage_profile`
+<a id="nestedatt--storage_profiles"></a>
+### Nested Schema for `storage_profiles`
 
 Read-Only:
 

--- a/docs/resources/vdc.md
+++ b/docs/resources/vdc.md
@@ -25,18 +25,18 @@ resource "cloudavenue_vdc" "example" {
   service_class         = "STD"
   storage_billing_model = "PAYG"
 
-  storage_profile {
-    class   = "gold"
-    default = true
-    limit   = 500
-  }
-
-  storage_profile {
-    class   = "silver"
-    default = false
-    limit   = 500
-  }
-
+  storage_profiles = [
+    {
+      class   = "gold"
+      default = true
+      limit   = 500
+    },
+    {
+      class   = "silver"
+      default = false
+      limit   = 500
+    },
+  ]
 }
 ```
 
@@ -60,6 +60,7 @@ The length must be between 2 and 27 characters.
 Changes to this field will force a new resource to be created.
 - `service_class` (String) The service class of the org VDC. It can be `ECO`, `STD`, `HP` or `VOIP`.
 - `storage_billing_model` (String) Choose Billing model of storage resources. It can be `PAYG` or `RESERVED`.
+- `storage_profiles` (Attributes Set) List of storage profiles for this VDC. (see [below for nested schema](#nestedatt--storage_profiles))
 - `vdc_group` (String) Name of an existing VDC group or a new one. This allows you to isolate your VDC.
 VMs of VDCs which belong to the same VDC group can communicate together.
 Changes to this field will force a new resource to be created.
@@ -67,15 +68,14 @@ Changes to this field will force a new resource to be created.
 ### Optional
 
 - `description` (String) The description of the org VDC.
-- `storage_profile` (Block List) List of storage profiles for this VDC. (see [below for nested schema](#nestedblock--storage_profile))
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
 
 - `id` (String) ID is the Name of the VCD.
 
-<a id="nestedblock--storage_profile"></a>
-### Nested Schema for `storage_profile`
+<a id="nestedatt--storage_profiles"></a>
+### Nested Schema for `storage_profiles`
 
 Required:
 
@@ -102,5 +102,5 @@ Import is supported using the following syntax:
 ```shell
 # VDC can be imported using the name.
 
-terraform import cloudavenue_vdc.vdc name
+terraform import cloudavenue_vdc.example name
 ```

--- a/examples/resources/cloudavenue_vdc/import.sh
+++ b/examples/resources/cloudavenue_vdc/import.sh
@@ -1,3 +1,3 @@
 # VDC can be imported using the name.
 
-terraform import cloudavenue_vdc.vdc name
+terraform import cloudavenue_vdc.example name

--- a/examples/resources/cloudavenue_vdc/resource.tf
+++ b/examples/resources/cloudavenue_vdc/resource.tf
@@ -10,16 +10,16 @@ resource "cloudavenue_vdc" "example" {
   service_class         = "STD"
   storage_billing_model = "PAYG"
 
-  storage_profile {
-    class   = "gold"
-    default = true
-    limit   = 500
-  }
-
-  storage_profile {
-    class   = "silver"
-    default = false
-    limit   = 500
-  }
-
+  storage_profiles = [
+    {
+      class   = "gold"
+      default = true
+      limit   = 500
+    },
+    {
+      class   = "silver"
+      default = false
+      limit   = 500
+    },
+  ]
 }

--- a/internal/provider/vdc/vdc_resource.go
+++ b/internal/provider/vdc/vdc_resource.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -55,7 +55,7 @@ type vdcResourceModel struct {
 	CPUAllocated           types.Float64            `tfsdk:"cpu_allocated"`
 	MemoryAllocated        types.Float64            `tfsdk:"memory_allocated"`
 	VdcStorageBillingModel types.String             `tfsdk:"storage_billing_model"`
-	VdcStorageProfiles     []vdcStorageProfileModel `tfsdk:"storage_profile"`
+	VdcStorageProfiles     []vdcStorageProfileModel `tfsdk:"storage_profiles"`
 	VdcGroup               types.String             `tfsdk:"vdc_group"`
 }
 
@@ -162,11 +162,10 @@ func (r *vdcResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp
 					stringvalidator.OneOf("PAYG", "RESERVED"),
 				},
 			},
-		},
-		Blocks: map[string]schema.Block{
-			"storage_profile": schema.ListNestedBlock{
+			"storage_profiles": schema.SetNestedAttribute{
+				Required:            true,
 				MarkdownDescription: "List of storage profiles for this VDC.",
-				NestedObject: schema.NestedBlockObject{
+				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"class": schema.StringAttribute{
 							Required: true,
@@ -190,8 +189,8 @@ func (r *vdcResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp
 						},
 					},
 				},
-				Validators: []validator.List{
-					listvalidator.SizeAtLeast(1),
+				Validators: []validator.Set{
+					setvalidator.SizeAtLeast(1),
 				},
 			},
 		},

--- a/internal/provider/vdc/vdcs_datasource.go
+++ b/internal/provider/vdc/vdcs_datasource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/client"
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/pkg/utils"
 )
 
 var (
@@ -87,7 +88,10 @@ func (d *vdcsDataSource) Configure(ctx context.Context, req datasource.Configure
 }
 
 func (d *vdcsDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data vdcsDataSourceModel
+	var (
+		data  vdcsDataSourceModel
+		names []string
+	)
 
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -109,9 +113,10 @@ func (d *vdcsDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 			VDCName: types.StringValue(v.VdcName),
 			VDCUuid: types.StringValue(v.VdcUuid),
 		})
+		names = append(names, v.VdcName)
 	}
 
-	data.ID = types.StringValue("frangipane")
+	data.ID = utils.GenerateUUID(names)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes
The Terrafom indicate that we must use attributes instead of blocks.
I have set `storage_profiles` as a SetNestedAttribute for this behavior.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested
Play with terraform. Import, Create and Delete are OK (but we can't delete the last VDC of a VDCGroup).

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->