### PR TITLE
chore(helper): add PlanModifierString `SetDefaultFunc`

### DIFF
--- a/internal/helpers/stringpm/README.md
+++ b/internal/helpers/stringpm/README.md
@@ -4,7 +4,7 @@ This helper is used to modify a string value in a plan.
 
 ## Helpers Available
 
-### `Default`
+### `SetDefault`
 
 This helper is used to set a default value for a string.
 
@@ -17,12 +17,12 @@ func (r *vappResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
                 Required:            true,
                 MarkdownDescription: "A name for ...",
                 PlanModifiers: []planmodifier.String{
-                    stringpm.Default("default-name"),
+                    stringpm.SetDefault("default-name"),
                 },
             },
 ```
 
-### `DefaultEnvVar`
+### `SetDefaultEnvVar`
 
 This helper is used to set a default value for a string from an environment variable.
 
@@ -39,7 +39,7 @@ func (r *vappResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
                 Required:            true,
                 MarkdownDescription: "A name for ...",
                 PlanModifiers: []planmodifier.String{
-                    stringpm.DefaultEnvVar("CAV_VAR_DEFAULT_NAME"),
+                    stringpm.SetDefaultEnvVar("CAV_VAR_DEFAULT_NAME"),
                 },
             },
 ```

--- a/internal/helpers/stringpm/README.md
+++ b/internal/helpers/stringpm/README.md
@@ -43,3 +43,26 @@ func (r *vappResource) Schema(ctx context.Context, _ resource.SchemaRequest, res
                 },
             },
 ```
+
+### `SetDefaultFunc`
+
+This helper is used to set a default value for a string using a function.
+
+```go
+// Schema defines the schema for the resource.
+func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "name": schema.StringAttribute{
+                Required:            true,
+                MarkdownDescription: "A name for ...",
+                PlanModifiers: []planmodifier.String{
+                    stringpm.SetDefaultFunc(stringpm.DefaultFunc(func(ctx context.Context, req planmodifier.StringRequest, resp *stringpm.DefaultFuncResponse) {
+                        if strings.Contains(req.PlanValue, "foo") {
+                            resp.Value = "bar"
+                            return
+                        }
+                    })),
+                },
+            },
+```

--- a/internal/helpers/stringpm/base_default_func.go
+++ b/internal/helpers/stringpm/base_default_func.go
@@ -1,0 +1,82 @@
+package stringpm
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// RequiresReplaceIfFunc is a conditional function used in the RequiresReplaceIf
+// plan modifier to determine whether the attribute requires replacement.
+type DefaultFunc func(context.Context, planmodifier.StringRequest, *DefaultFuncResponse)
+
+// RequiresReplaceIfFuncResponse is the response type for a RequiresReplaceIfFunc.
+type DefaultFuncResponse struct {
+	// Diagnostics report errors or warnings related to this logic. An empty
+	// or unset slice indicates success, with no warnings or errors generated.
+	Diagnostics diag.Diagnostics
+
+	// Value is the value to use by default if the attribute is not configured.
+	Value string
+}
+
+// setDefaultFunc returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The given function returns true. Returning false will not unset any
+//     prior resource replacement.
+func setDefaultFunc(f DefaultFunc, description, markdownDescription string) planmodifier.String {
+	return defaultFuncPlanModifier{
+		f:                   f,
+		description:         description,
+		markdownDescription: markdownDescription,
+	}
+}
+
+// defaultFuncPlanModifier is an plan modifier that sets RequiresReplace
+// on the attribute if a given function is true.
+type defaultFuncPlanModifier struct {
+	f                   DefaultFunc
+	description         string
+	markdownDescription string
+}
+
+// Description returns a human-readable description of the plan modifier.
+func (m defaultFuncPlanModifier) Description(_ context.Context) string {
+	return m.description
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m defaultFuncPlanModifier) MarkdownDescription(_ context.Context) string {
+	return m.markdownDescription
+}
+
+// PlanModifyString implements the plan modification logic.
+func (m defaultFuncPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Do not replace if the plan and state values are equal.
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	// If the attribute configuration is not null, we are done here
+	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// If the attribute plan is "known" and "not null", then a previous plan modifier in the sequence
+	// has already been applied, and we don't want to interfere.
+	if !req.PlanValue.IsUnknown() && !req.PlanValue.IsNull() {
+		return
+	}
+
+	funcResp := &DefaultFuncResponse{}
+
+	m.f(ctx, req, funcResp)
+
+	resp.Diagnostics.Append(funcResp.Diagnostics...)
+	resp.PlanValue = types.StringValue(funcResp.Value)
+}

--- a/internal/helpers/stringpm/default.go
+++ b/internal/helpers/stringpm/default.go
@@ -2,41 +2,22 @@ package stringpm
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func Default(str string) planmodifier.String {
-	return &defaultPlanModifier{str}
-}
-
-type defaultPlanModifier struct {
-	value string
-}
-
-var _ planmodifier.String = (*defaultPlanModifier)(nil)
-
-func (str *defaultPlanModifier) Description(ctx context.Context) string {
-	return fmt.Sprintf("Default value: %s", str)
-}
-
-func (str *defaultPlanModifier) MarkdownDescription(ctx context.Context) string {
-	return fmt.Sprintf("Default value: `%s`", str)
-}
-
-func (str *defaultPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	// If the attribute configuration is not null, we are done here
-	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() {
-		return
-	}
-
-	// If the attribute plan is "known" and "not null", then a previous plan modifier in the sequence
-	// has already been applied, and we don't want to interfere.
-	if !req.PlanValue.IsUnknown() && !req.PlanValue.IsNull() {
-		return
-	}
-
-	resp.PlanValue = types.StringValue(str.value)
+// SetDefault returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The plan or state values are not null or known
+func SetDefault(str string) planmodifier.String {
+	return setDefaultFunc(
+		func(ctx context.Context, req planmodifier.StringRequest, resp *DefaultFuncResponse) {
+			resp.Value = str
+		},
+		"Set default value",
+		"Set default value",
+	)
 }

--- a/internal/helpers/stringpm/default_env_var.go
+++ b/internal/helpers/stringpm/default_env_var.go
@@ -6,45 +6,25 @@ import (
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-func DefaultEnvVar(envVar string) planmodifier.String {
-	return &stringDefaultEnvVarPlanModifier{envVar}
-}
-
-type stringDefaultEnvVarPlanModifier struct {
-	EnvVar string
-}
-
-var _ planmodifier.String = (*stringDefaultEnvVarPlanModifier)(nil)
-
-func (env *stringDefaultEnvVarPlanModifier) Description(ctx context.Context) string {
-	return fmt.Sprintf("Default value: %s", env.EnvVar)
-}
-
-func (env *stringDefaultEnvVarPlanModifier) MarkdownDescription(ctx context.Context) string {
-	return fmt.Sprintf("Default value: `%s`", env.EnvVar)
-}
-
-func (env *stringDefaultEnvVarPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	// If the attribute configuration is not null, we are done here
-	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() {
-		return
-	}
-
-	// If the attribute plan is "known" and "not null", then a previous plan modifier in the sequence
-	// has already been applied, and we don't want to interfere.
-	if !req.PlanValue.IsUnknown() && !req.PlanValue.IsNull() {
-		return
-	}
-
-	// Load the value from the environment variable
-	// If the environment variable is not set, we are done here
-	v := types.StringValue(os.Getenv(env.EnvVar))
-	if !v.IsNull() {
-		resp.PlanValue = v
-	} else {
-		resp.Diagnostics.AddError("Environment variable not set", fmt.Sprintf("The environment variable %s is not set", env.EnvVar))
-	}
+// SetDefaultFunc returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The plan or state values are not null or known
+func SetDefaultEnvVar(envVar string) planmodifier.String {
+	return setDefaultFunc(
+		func(ctx context.Context, req planmodifier.StringRequest, resp *DefaultFuncResponse) {
+			v := os.Getenv(envVar)
+			if v != "" {
+				resp.Value = v
+			} else {
+				resp.Diagnostics.AddError("Environment variable not set", fmt.Sprintf("The environment variable %s is not set", envVar))
+			}
+		},
+		"Set default value from environment variable",
+		"Set default value from environment variable",
+	)
 }

--- a/internal/helpers/stringpm/default_env_var_test.go
+++ b/internal/helpers/stringpm/default_env_var_test.go
@@ -91,7 +91,7 @@ func TestDefaultEnvVarModifierPlanModifyString(t *testing.T) {
 				PlanValue: testCase.request.PlanValue,
 			}
 
-			stringpm.DefaultEnvVar(envVarName).PlanModifyString(context.Background(), testCase.request, resp)
+			stringpm.SetDefaultEnvVar(envVarName).PlanModifyString(context.Background(), testCase.request, resp)
 
 			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/internal/helpers/stringpm/default_func.go
+++ b/internal/helpers/stringpm/default_func.go
@@ -1,0 +1,17 @@
+package stringpm
+
+import "github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+
+// SetDefaultFunc returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The plan or state values are not null or known
+func SetDefaultFunc(f DefaultFunc) planmodifier.String {
+	return setDefaultFunc(
+		f,
+		"Set default value",
+		"Set default value",
+	)
+}

--- a/internal/helpers/stringpm/default_func_test.go
+++ b/internal/helpers/stringpm/default_func_test.go
@@ -1,0 +1,101 @@
+package stringpm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dchest/uniuri"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/stringpm"
+)
+
+func TestDefaultFuncModifierPlanModifyString(t *testing.T) {
+	expectedValue := uniuri.New()
+
+	testCases := map[string]struct {
+		request  planmodifier.StringRequest
+		expected *planmodifier.StringResponse
+	}{
+		"null-state": {
+			// when we first create the resource, use the unknown
+			// value
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringNull(),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringNull(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringValue(expectedValue),
+			},
+		},
+		"known-plan": {
+			// this would really only happen if we had a plan
+			// modifier setting the value before this plan modifier
+			// got to it
+			//
+			// but we still want to preserve that value, in this
+			// case
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue("other"),
+				PlanValue:   types.StringValue("test"),
+				ConfigValue: types.StringNull(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringValue("test"),
+			},
+		},
+		"non-null-state-unknown-plan": {
+			// this is the situation we want to preserve the state
+			// in
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue("test"),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringNull(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringValue(expectedValue),
+			},
+		},
+		"unknown-config": {
+			// this is the situation in which a user is
+			// interpolating into a field. We want that to still
+			// show up as unknown, otherwise they'll get apply-time
+			// errors for changing the value even though we knew it
+			// was legitimately possible for it to change and the
+			// provider can't prevent this from happening
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue("test"),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringUnknown(),
+			},
+			expected: &planmodifier.StringResponse{
+				PlanValue: types.StringValue(expectedValue),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			// t.Parallel()
+
+			resp := &planmodifier.StringResponse{
+				PlanValue: testCase.request.PlanValue,
+			}
+
+			x := stringpm.DefaultFunc(func(ctx context.Context, req planmodifier.StringRequest, resp *stringpm.DefaultFuncResponse) {
+				resp.Value = expectedValue
+			})
+
+			stringpm.SetDefaultFunc(x).PlanModifyString(context.Background(), testCase.request, resp)
+
+			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/helpers/stringpm/default_test.go
+++ b/internal/helpers/stringpm/default_test.go
@@ -87,7 +87,7 @@ func TestDefaultModifierPlanModifyString(t *testing.T) {
 				PlanValue: testCase.request.PlanValue,
 			}
 
-			stringpm.Default(expectedValue).PlanModifyString(context.Background(), testCase.request, resp)
+			stringpm.SetDefault(expectedValue).PlanModifyString(context.Background(), testCase.request, resp)
 
 			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)


### PR DESCRIPTION
### Description of your changes

Close #65 

### How has this code been tested

```
go test -count=1 -v ./internal/helpers/stringpm/
=== RUN   TestDefaultEnvVarModifierPlanModifyString
=== RUN   TestDefaultEnvVarModifierPlanModifyString/null-state
=== RUN   TestDefaultEnvVarModifierPlanModifyString/known-plan
=== RUN   TestDefaultEnvVarModifierPlanModifyString/non-null-state-unknown-plan
=== RUN   TestDefaultEnvVarModifierPlanModifyString/unknown-config
--- PASS: TestDefaultEnvVarModifierPlanModifyString (0.00s)
    --- PASS: TestDefaultEnvVarModifierPlanModifyString/null-state (0.00s)
    --- PASS: TestDefaultEnvVarModifierPlanModifyString/known-plan (0.00s)
    --- PASS: TestDefaultEnvVarModifierPlanModifyString/non-null-state-unknown-plan (0.00s)
    --- PASS: TestDefaultEnvVarModifierPlanModifyString/unknown-config (0.00s)
=== RUN   TestDefaultFuncModifierPlanModifyString
=== RUN   TestDefaultFuncModifierPlanModifyString/null-state
=== RUN   TestDefaultFuncModifierPlanModifyString/known-plan
=== RUN   TestDefaultFuncModifierPlanModifyString/non-null-state-unknown-plan
=== RUN   TestDefaultFuncModifierPlanModifyString/unknown-config
--- PASS: TestDefaultFuncModifierPlanModifyString (0.00s)
    --- PASS: TestDefaultFuncModifierPlanModifyString/null-state (0.00s)
    --- PASS: TestDefaultFuncModifierPlanModifyString/known-plan (0.00s)
    --- PASS: TestDefaultFuncModifierPlanModifyString/non-null-state-unknown-plan (0.00s)
    --- PASS: TestDefaultFuncModifierPlanModifyString/unknown-config (0.00s)
=== RUN   TestDefaultModifierPlanModifyString
=== RUN   TestDefaultModifierPlanModifyString/null-state
=== RUN   TestDefaultModifierPlanModifyString/known-plan
=== RUN   TestDefaultModifierPlanModifyString/non-null-state-unknown-plan
=== RUN   TestDefaultModifierPlanModifyString/unknown-config
--- PASS: TestDefaultModifierPlanModifyString (0.00s)
    --- PASS: TestDefaultModifierPlanModifyString/null-state (0.00s)
    --- PASS: TestDefaultModifierPlanModifyString/known-plan (0.00s)
    --- PASS: TestDefaultModifierPlanModifyString/non-null-state-unknown-plan (0.00s)
    --- PASS: TestDefaultModifierPlanModifyString/unknown-config (0.00s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/stringpm  0.672s
```