### PR TITLE
chore(helper): add PlanModifier boolean `SetDefault...` 

### DIFF
--- a/internal/helpers/boolpm/README.md
+++ b/internal/helpers/boolpm/README.md
@@ -1,0 +1,68 @@
+# CloudAvenue Plan Modifier Bool Helper
+
+This helper is used to modify a boolean value in a plan.
+
+## Helpers Available
+
+### `SetDefault`
+
+This helper is used to set a default value for a boolean.
+
+```go
+// Schema defines the schema for the resource.
+func (r *vappResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "enabled": schema.BoolAttribute{
+                Required:            true,
+                MarkdownDescription: "Enable or disable ...",
+                PlanModifiers: []planmodifier.Bool{
+                    boolpm.SetDefault(true),
+                },
+            },
+```
+
+### `SetDefaultEnvVar`
+
+This helper is used to set a default value for a boolean from an environment variable.
+
+```sh
+export CAV_VAR_DEFAULT_NAME="true"
+```
+
+```go
+// Schema defines the schema for the resource.
+func (r *vappResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "enabled": schema.BoolAttribute{
+                Required:            true,
+                MarkdownDescription: "Enable or disable ...",
+                PlanModifiers: []planmodifier.Bool{
+                    boolpm.SetDefaultEnvVar("CAV_VAR_DEFAULT_NAME"),
+                },
+            },
+```
+
+### `SetDefaultFunc`
+
+This helper is used to set a default value for a boolean using a function.
+
+```go
+// Schema defines the schema for the resource.
+func (r *xResource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        (...)
+            "enabled": schema.BoolAttribute{
+                Required:            true,
+                MarkdownDescription: "Enable or disable ...",
+                PlanModifiers: []planmodifier.Bool{
+                    boolpm.SetDefaultFunc(boolpm.DefaultFunc(func(ctx context.Context, req planmodifier.BoolRequest, resp *boolpm.DefaultFuncResponse) {
+                        if os.Getenv("CAV_VAR_1") == "foo" && os.Getenv("CAV_VAR_2") == "bar" {
+                            resp.Value = true
+                            return
+                        }
+                    })),
+                },
+            },
+```

--- a/internal/helpers/boolpm/base_default_func.go
+++ b/internal/helpers/boolpm/base_default_func.go
@@ -1,0 +1,82 @@
+package boolpm
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// DefaultFunc is a function that can be used to set a default value for a
+// boolean attribute.
+type DefaultFunc func(context.Context, planmodifier.BoolRequest, *DefaultFuncResponse)
+
+// DefaultFuncResponse is the response type for a DefaultFunc.
+type DefaultFuncResponse struct {
+	// Diagnostics report errors or warnings related to this logic. An empty
+	// or unset slice indicates success, with no warnings or errors generated.
+	Diagnostics diag.Diagnostics
+
+	// Value is the value to use by default if the attribute is not configured.
+	Value bool
+}
+
+// setDefaultFunc returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The given function returns true. Returning false will not unset any
+//     prior resource replacement.
+func setDefaultFunc(f DefaultFunc, description, markdownDescription string) planmodifier.Bool {
+	return defaultFuncPlanModifier{
+		f:                   f,
+		description:         description,
+		markdownDescription: markdownDescription,
+	}
+}
+
+// defaultFuncPlanModifier is an plan modifier that sets RequiresReplace
+// on the attribute if a given function is true.
+type defaultFuncPlanModifier struct {
+	f                   DefaultFunc
+	description         string
+	markdownDescription string
+}
+
+// Description returns a human-readable description of the plan modifier.
+func (m defaultFuncPlanModifier) Description(_ context.Context) string {
+	return m.description
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m defaultFuncPlanModifier) MarkdownDescription(_ context.Context) string {
+	return m.markdownDescription
+}
+
+// PlanModifyBool implements the plan modification logic.
+func (m defaultFuncPlanModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	// Do not replace if the plan and state values are equal.
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	// If the attribute configuration is not null, we are done here
+	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// If the attribute plan is "known" and "not null", then a previous plan modifier in the sequence
+	// has already been applied, and we don't want to interfere.
+	if !req.PlanValue.IsUnknown() && !req.PlanValue.IsNull() {
+		return
+	}
+
+	funcResp := &DefaultFuncResponse{}
+
+	m.f(ctx, req, funcResp)
+
+	resp.Diagnostics.Append(funcResp.Diagnostics...)
+	resp.PlanValue = types.BoolValue(funcResp.Value)
+}

--- a/internal/helpers/boolpm/default.go
+++ b/internal/helpers/boolpm/default.go
@@ -1,0 +1,23 @@
+package boolpm
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// SetDefault returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The plan or state values are not null or known
+func SetDefault(str bool) planmodifier.Bool {
+	return setDefaultFunc(
+		func(ctx context.Context, req planmodifier.BoolRequest, resp *DefaultFuncResponse) {
+			resp.Value = str
+		},
+		"Set default value",
+		"Set default value",
+	)
+}

--- a/internal/helpers/boolpm/default_env_var.go
+++ b/internal/helpers/boolpm/default_env_var.go
@@ -1,0 +1,37 @@
+package boolpm
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// SetDefaultFunc returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The plan or state values are not null or known
+func SetDefaultEnvVar(envVar string) planmodifier.Bool {
+	return setDefaultFunc(
+		func(ctx context.Context, req planmodifier.BoolRequest, resp *DefaultFuncResponse) {
+			v := os.Getenv(envVar)
+			if v != "" {
+				// Parse string to bool
+				b, err := strconv.ParseBool(v)
+				if err != nil {
+					resp.Diagnostics.AddError("Environment variable set but is not Boolean", fmt.Sprintf("The environment variable %s is set but is not a Boolean", envVar))
+					return
+				}
+				resp.Value = b
+			} else {
+				resp.Diagnostics.AddError("Environment variable not set", fmt.Sprintf("The environment variable %s is not set", envVar))
+			}
+		},
+		"Set default value from environment variable",
+		"Set default value from environment variable",
+	)
+}

--- a/internal/helpers/boolpm/default_env_var_test.go
+++ b/internal/helpers/boolpm/default_env_var_test.go
@@ -1,0 +1,99 @@
+package boolpm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/boolpm"
+)
+
+func TestDefaultEnvVarModifierPlanModifyBool(t *testing.T) {
+	const (
+		envVarName = "TEST_VAR"
+		envValue   = true
+	)
+
+	testCases := map[string]struct {
+		request  planmodifier.BoolRequest
+		expected *planmodifier.BoolResponse
+	}{
+		"null-state": {
+			// when we first create the resource, use the unknown
+			// value
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolNull(),
+				PlanValue:   types.BoolUnknown(),
+				ConfigValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(envValue),
+			},
+		},
+		"known-plan": {
+			// this would really only happen if we had a plan
+			// modifier setting the value before this plan modifier
+			// got to it
+			//
+			// but we still want to preserve that value, in this
+			// case
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolValue(false),
+				PlanValue:   types.BoolValue(true),
+				ConfigValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(true),
+			},
+		},
+		"non-null-state-unknown-plan": {
+			// this is the situation we want to preserve the state
+			// in
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolValue(true),
+				PlanValue:   types.BoolUnknown(),
+				ConfigValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(envValue),
+			},
+		},
+		"unknown-config": {
+			// this is the situation in which a user is
+			// interpolating into a field. We want that to still
+			// show up as unknown, otherwise they'll get apply-time
+			// errors for changing the value even though we knew it
+			// was legitimately possible for it to change and the
+			// provider can't prevent this from happening
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolValue(true),
+				PlanValue:   types.BoolUnknown(),
+				ConfigValue: types.BoolUnknown(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(envValue),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+		// set environnement variable
+		t.Setenv(envVarName, "true")
+
+		t.Run(name, func(t *testing.T) {
+			resp := &planmodifier.BoolResponse{
+				PlanValue: testCase.request.PlanValue,
+			}
+
+			boolpm.SetDefaultEnvVar(envVarName).PlanModifyBool(context.Background(), testCase.request, resp)
+
+			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/helpers/boolpm/default_func.go
+++ b/internal/helpers/boolpm/default_func.go
@@ -1,0 +1,17 @@
+package boolpm
+
+import "github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+
+// SetDefaultFunc returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The plan or state values are not null or known
+func SetDefaultFunc(f DefaultFunc) planmodifier.Bool {
+	return setDefaultFunc(
+		f,
+		"Set default value",
+		"Set default value",
+	)
+}

--- a/internal/helpers/boolpm/default_func_test.go
+++ b/internal/helpers/boolpm/default_func_test.go
@@ -1,0 +1,100 @@
+package boolpm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/boolpm"
+)
+
+func TestDefaultFuncModifierPlanModifyBool(t *testing.T) {
+	expectedValue := true
+
+	testCases := map[string]struct {
+		request  planmodifier.BoolRequest
+		expected *planmodifier.BoolResponse
+	}{
+		"null-state": {
+			// when we first create the resource, use the unknown
+			// value
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolNull(),
+				PlanValue:   types.BoolUnknown(),
+				ConfigValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(expectedValue),
+			},
+		},
+		"known-plan": {
+			// this would really only happen if we had a plan
+			// modifier setting the value before this plan modifier
+			// got to it
+			//
+			// but we still want to preserve that value, in this
+			// case
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolValue(false),
+				PlanValue:   types.BoolValue(true),
+				ConfigValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(true),
+			},
+		},
+		"non-null-state-unknown-plan": {
+			// this is the situation we want to preserve the state
+			// in
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolValue(false),
+				PlanValue:   types.BoolUnknown(),
+				ConfigValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(expectedValue),
+			},
+		},
+		"unknown-config": {
+			// this is the situation in which a user is
+			// interpolating into a field. We want that to still
+			// show up as unknown, otherwise they'll get apply-time
+			// errors for changing the value even though we knew it
+			// was legitimately possible for it to change and the
+			// provider can't prevent this from happening
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolValue(false),
+				PlanValue:   types.BoolUnknown(),
+				ConfigValue: types.BoolUnknown(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(expectedValue),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			// t.Parallel()
+
+			resp := &planmodifier.BoolResponse{
+				PlanValue: testCase.request.PlanValue,
+			}
+
+			x := boolpm.DefaultFunc(func(ctx context.Context, req planmodifier.BoolRequest, resp *boolpm.DefaultFuncResponse) {
+				resp.Value = expectedValue
+			})
+
+			boolpm.SetDefaultFunc(x).PlanModifyBool(context.Background(), testCase.request, resp)
+
+			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/helpers/boolpm/default_test.go
+++ b/internal/helpers/boolpm/default_test.go
@@ -1,0 +1,96 @@
+package boolpm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/boolpm"
+)
+
+func TestDefaultModifierPlanModifyBool(t *testing.T) {
+	expectedValue := true
+
+	testCases := map[string]struct {
+		request  planmodifier.BoolRequest
+		expected *planmodifier.BoolResponse
+	}{
+		"null-state": {
+			// when we first create the resource, use the unknown
+			// value
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolNull(),
+				PlanValue:   types.BoolUnknown(),
+				ConfigValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(expectedValue),
+			},
+		},
+		"known-plan": {
+			// this would really only happen if we had a plan
+			// modifier setting the value before this plan modifier
+			// got to it
+			//
+			// but we still want to preserve that value, in this
+			// case
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolValue(false),
+				PlanValue:   types.BoolValue(true),
+				ConfigValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(true),
+			},
+		},
+		"non-null-state-unknown-plan": {
+			// this is the situation we want to preserve the state
+			// in
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolValue(false),
+				PlanValue:   types.BoolUnknown(),
+				ConfigValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(expectedValue),
+			},
+		},
+		"unknown-config": {
+			// this is the situation in which a user is
+			// interpolating into a field. We want that to still
+			// show up as unknown, otherwise they'll get apply-time
+			// errors for changing the value even though we knew it
+			// was legitimately possible for it to change and the
+			// provider can't prevent this from happening
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolValue(false),
+				PlanValue:   types.BoolUnknown(),
+				ConfigValue: types.BoolUnknown(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(expectedValue),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			// t.Parallel()
+
+			resp := &planmodifier.BoolResponse{
+				PlanValue: testCase.request.PlanValue,
+			}
+
+			boolpm.SetDefault(expectedValue).PlanModifyBool(context.Background(), testCase.request, resp)
+
+			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes

Close #74 

### How has this code been tested

```
go test -count=1 -v ./internal/helpers/boolpm/
=== RUN   TestDefaultEnvVarModifierPlanModifyBool
=== RUN   TestDefaultEnvVarModifierPlanModifyBool/null-state
=== RUN   TestDefaultEnvVarModifierPlanModifyBool/known-plan
=== RUN   TestDefaultEnvVarModifierPlanModifyBool/non-null-state-unknown-plan
=== RUN   TestDefaultEnvVarModifierPlanModifyBool/unknown-config
--- PASS: TestDefaultEnvVarModifierPlanModifyBool (0.00s)
    --- PASS: TestDefaultEnvVarModifierPlanModifyBool/null-state (0.00s)
    --- PASS: TestDefaultEnvVarModifierPlanModifyBool/known-plan (0.00s)
    --- PASS: TestDefaultEnvVarModifierPlanModifyBool/non-null-state-unknown-plan (0.00s)
    --- PASS: TestDefaultEnvVarModifierPlanModifyBool/unknown-config (0.00s)
=== RUN   TestDefaultFuncModifierPlanModifyBool
=== RUN   TestDefaultFuncModifierPlanModifyBool/null-state
=== RUN   TestDefaultFuncModifierPlanModifyBool/known-plan
=== RUN   TestDefaultFuncModifierPlanModifyBool/non-null-state-unknown-plan
=== RUN   TestDefaultFuncModifierPlanModifyBool/unknown-config
--- PASS: TestDefaultFuncModifierPlanModifyBool (0.00s)
    --- PASS: TestDefaultFuncModifierPlanModifyBool/null-state (0.00s)
    --- PASS: TestDefaultFuncModifierPlanModifyBool/known-plan (0.00s)
    --- PASS: TestDefaultFuncModifierPlanModifyBool/non-null-state-unknown-plan (0.00s)
    --- PASS: TestDefaultFuncModifierPlanModifyBool/unknown-config (0.00s)
=== RUN   TestDefaultModifierPlanModifyBool
=== RUN   TestDefaultModifierPlanModifyBool/unknown-config
=== RUN   TestDefaultModifierPlanModifyBool/null-state
=== RUN   TestDefaultModifierPlanModifyBool/known-plan
=== RUN   TestDefaultModifierPlanModifyBool/non-null-state-unknown-plan
--- PASS: TestDefaultModifierPlanModifyBool (0.00s)
    --- PASS: TestDefaultModifierPlanModifyBool/unknown-config (0.00s)
    --- PASS: TestDefaultModifierPlanModifyBool/null-state (0.00s)
    --- PASS: TestDefaultModifierPlanModifyBool/known-plan (0.00s)
    --- PASS: TestDefaultModifierPlanModifyBool/non-null-state-unknown-plan (0.00s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/boolpm    0.384s
```
