### PR TITLE
ci: restrict lint and generate diff on PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,11 @@ name: Tests
 # Optionally, you can turn it on using a schedule for regular testing.
 on:
   pull_request:
-    paths-ignore:
-      - 'README.md'
-  push:
-    paths-ignore:
-      - 'README.md'
+    branches:
+      - main
+    paths:
+      - '**.go'
+      - 'examples/**'
 
 # Testing only needs permissions to read the repository contents.
 permissions:


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes
Restrict the Lint Job on PR on main branch when Go or examples files have been modified.
