### PR TITLE
refactor(vapp): replace deprecated Blocks

### DIFF
--- a/docs/resources/vapp_vm_internal_disk.md
+++ b/docs/resources/vapp_vm_internal_disk.md
@@ -17,7 +17,7 @@ resource "cloudavenue_vapp_vm_internal_disk" "example" {
   vapp_name       = "vapp_test3"
   vm_name         = "TestRomain"
 	allow_vm_reboot = true
-	internal_disk {
+	internal_disk = {
 		bus_type      = "sata"
 		size_in_mb    = "500"
 		bus_number    = 0
@@ -37,14 +37,14 @@ resource "cloudavenue_vapp_vm_internal_disk" "example" {
 ### Optional
 
 - `allow_vm_reboot` (Boolean) Powers off VM when changing any attribute of an IDE disk or unit/bus number of other disk types, after the change is complete VM is powered back on. Without this setting enabled, such changes on a powered-on VM would fail.
-- `internal_disk` (Block, Optional) The internal disk configuration. See [internal_disk](#internal_disk) below for details. (see [below for nested schema](#nestedblock--internal_disk))
+- `internal_disk` (Attributes) A block to define disk. Multiple can be used. (see [below for nested schema](#nestedatt--internal_disk))
 - `vdc` (String) The name of VDC to use, optional if defined at provider level.
 
 ### Read-Only
 
 - `id` (String) The ID of the internal disk.
 
-<a id="nestedblock--internal_disk"></a>
+<a id="nestedatt--internal_disk"></a>
 ### Nested Schema for `internal_disk`
 
 Required:

--- a/examples/resources/cloudavenue_vapp_vm_internal_disk/resource.tf
+++ b/examples/resources/cloudavenue_vapp_vm_internal_disk/resource.tf
@@ -2,7 +2,7 @@ resource "cloudavenue_vapp_vm_internal_disk" "example" {
   vapp_name       = "vapp_test3"
   vm_name         = "TestRomain"
 	allow_vm_reboot = true
-	internal_disk {
+	internal_disk = {
 		bus_type      = "sata"
 		size_in_mb    = "500"
 		bus_number    = 0

--- a/internal/provider/vapp/vm_internal_disk_resource.go
+++ b/internal/provider/vapp/vm_internal_disk_resource.go
@@ -91,10 +91,9 @@ func (r *internalDiskResource) Schema(ctx context.Context, _ resource.SchemaRequ
 				PlanModifiers:       []planmodifier.Bool{boolpm.SetDefault(false)},
 				MarkdownDescription: "Powers off VM when changing any attribute of an IDE disk or unit/bus number of other disk types, after the change is complete VM is powered back on. Without this setting enabled, such changes on a powered-on VM would fail.",
 			},
-		},
-		Blocks: map[string]schema.Block{
-			"internal_disk": schema.SingleNestedBlock{
-				MarkdownDescription: "The internal disk configuration. See [internal_disk](#internal_disk) below for details.",
+			"internal_disk": schema.SingleNestedAttribute{
+				MarkdownDescription: "A block to define disk. Multiple can be used.",
+				Optional:            true,
 				Attributes:          vm.InternalDiskSchema(),
 			},
 		},

--- a/internal/tests/vapp_vm_internal_disk_resource_test.go
+++ b/internal/tests/vapp_vm_internal_disk_resource_test.go
@@ -15,7 +15,7 @@ resource "cloudavenue_vapp_vm_internal_disk" "example" {
   vapp_name       = "vapp_test3"
   vm_name         = "TestRomain"
 	allow_vm_reboot = true
-	internal_disk {
+	internal_disk = {
 		bus_type      = "sata"
 		size_in_mb    = "500"
 		bus_number    = 0


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
```
=== RUN   TestAccVMInternalDiskResource
--- PASS: TestAccVMInternalDiskResource (37.28s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests     37.397s
```
