### PR TITLE
fix(vapp): bad import on org_network_resource if VDC is in the ID

### DIFF
--- a/internal/provider/vapp/org_network_resource.go
+++ b/internal/provider/vapp/org_network_resource.go
@@ -373,7 +373,7 @@ func (r *orgNetworkResource) ImportState(ctx context.Context, req resource.Impor
 		NetworkName: types.StringValue(resourceURI[1]),
 	}
 
-	if len(resourceURI) == 4 {
+	if len(resourceURI) == 3 {
 		state = &orgNetworkResourceModel{
 			VDC:         types.StringValue(resourceURI[0]),
 			VAppName:    types.StringValue(resourceURI[1]),

--- a/internal/tests/vapp/org_network_resource_test.go
+++ b/internal/tests/vapp/org_network_resource_test.go
@@ -43,11 +43,18 @@ func TestAccOrgNetworkResource(t *testing.T) {
 			// },
 			// ImportruetState testing
 			{
-				// Import test with vdc
+				// Import test without vdc
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateId:     "vapp_test3.test_remi",
+			},
+			{
+				// Import test with vdc
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "VDC_Frangipane.vapp_test3.test_remi",
 			},
 		},
 	})


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
```
❯ TF_ACC=1 go test -v -count=1  -run TestAccOrgNetworkResource  ./internal/tests/vapp
=== RUN   TestAccOrgNetworkResource
--- PASS: TestAccOrgNetworkResource (17.02s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/vapp        17.315s
```
