### PR TITLE
refactor: add common acl func

### DIFF
--- a/internal/provider/common/acl/acl.go
+++ b/internal/provider/common/acl/acl.go
@@ -1,6 +1,8 @@
 package acl
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -8,6 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	govcdtypes "github.com/vmware/go-vcloud-director/v2/types/v56"
+
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common"
 )
 
 type SharedWithModel struct {
@@ -88,4 +94,82 @@ func Schema(readOnly bool) map[string]schema.Attribute {
 			},
 		},
 	}
+}
+
+func SharedSetToAccessControl(client *govcd.VCDClient, org *govcd.AdminOrg, input []SharedWithModel) ([]*govcdtypes.AccessSetting, []*SharedWithModel, error) {
+	var output []*govcdtypes.AccessSetting
+	var outputModel []*SharedWithModel
+
+	for _, item := range input {
+		var subjectHref string
+		var subjectType string
+		var subjectName string
+		var oModel *SharedWithModel
+
+		if !item.UserID.IsNull() && !item.UserID.IsUnknown() {
+			userID := item.UserID.ValueString()
+			user, err := org.GetUserById(userID, false)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error retrieving user %s: %w", userID, err)
+			}
+			subjectHref = user.User.Href
+			subjectType = user.User.Type
+			subjectName = user.User.Name
+
+			oModel = &SharedWithModel{
+				UserID:      types.StringValue("urn:vcloud:user:" + common.ExtractUUID(subjectHref)),
+				SubjectName: types.StringValue(subjectName),
+			}
+		} else if !item.GroupID.IsNull() && !item.GroupID.IsUnknown() {
+			groupID := item.GroupID.ValueString()
+			group, err := org.GetGroupById(groupID, false)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error retrieving group %s: %w", groupID, err)
+			}
+			subjectHref = group.Group.Href
+			subjectType = group.Group.Type
+			subjectName = group.Group.Name
+			oModel = &SharedWithModel{
+				GroupID:     types.StringValue("urn:vcloud:group:" + common.ExtractUUID(subjectHref)),
+				SubjectName: types.StringValue(subjectName),
+			}
+		}
+
+		accessLevel := item.AccessLevel.ValueString()
+
+		output = append(output, &govcdtypes.AccessSetting{
+			Subject: &govcdtypes.LocalSubject{
+				HREF: subjectHref,
+				Name: subjectName,
+				Type: subjectType,
+			},
+			ExternalSubject: nil,
+			AccessLevel:     accessLevel,
+		})
+		oModel.AccessLevel = types.StringValue(accessLevel)
+		outputModel = append(outputModel, oModel)
+	}
+	return output, outputModel, nil
+}
+
+func AccessControlListToSharedSet(input []*govcdtypes.AccessSetting) ([]SharedWithModel, error) {
+	var output []SharedWithModel
+
+	for _, item := range input {
+		o := SharedWithModel{}
+
+		switch item.Subject.Type {
+		case govcdtypes.MimeAdminUser:
+			o.UserID = types.StringValue("urn:vcloud:user:" + common.ExtractUUID(item.Subject.HREF))
+		case govcdtypes.MimeAdminGroup:
+			o.GroupID = types.StringValue("urn:vcloud:group:" + common.ExtractUUID(item.Subject.HREF))
+		default:
+			return nil, fmt.Errorf("unhandled type '%s' for item %s", item.Subject.Type, item.Subject.Name)
+		}
+		o.AccessLevel = types.StringValue(item.AccessLevel)
+		o.SubjectName = types.StringValue(item.Subject.Name)
+
+		output = append(output, o)
+	}
+	return output, nil
 }

--- a/internal/tests/vapp/acl_resource_test.go
+++ b/internal/tests/vapp/acl_resource_test.go
@@ -9,8 +9,9 @@ import (
 	tests "github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/common"
 )
 
-const testAccAccessControlResourceConfig = `
+const testAccACLResourceConfig = `
 resource "cloudavenue_vapp_acl" "example" {
+	vdc                  = "MyVDC" # Optional
 	vapp_name            = "MyVapp"
 	shared_with = [{
 	  access_level = "ReadOnly"
@@ -23,14 +24,15 @@ resource "cloudavenue_vapp_acl" "example" {
   }
 `
 
-const testAccAccessControlResourceUpdateConfig = `
+const testAccACLResourceUpdateConfig = `
 resource "cloudavenue_vapp_acl" "example" {
-	vapp_name            = "MyVapp"
+	vdc                   = "MyVDC" # Optional
+	vapp_name             = "MyVapp"
 	everyone_access_level = "Change"
   }
 `
 
-func TestAccAccessControlResource(t *testing.T) {
+func TestAccACLResource(t *testing.T) {
 	const resourceName = "cloudavenue_vapp_acl.example"
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { tests.TestAccPreCheck(t) },
@@ -39,7 +41,7 @@ func TestAccAccessControlResource(t *testing.T) {
 			// Read testing
 			{
 				// Apply test
-				Config: testAccAccessControlResourceConfig,
+				Config: testAccACLResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`(urn:vcloud:vapp:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})`)),
 					resource.TestCheckResourceAttr(resourceName, "vdc", "MyVDC"),
@@ -51,7 +53,7 @@ func TestAccAccessControlResource(t *testing.T) {
 			// Uncomment if you want to test update or delete this block
 			{
 				// Update test
-				Config: testAccAccessControlResourceUpdateConfig,
+				Config: testAccACLResourceUpdateConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(`(urn:vcloud:vapp:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})`)),
 					resource.TestCheckResourceAttr(resourceName, "vdc", "MyVDC"),
@@ -66,6 +68,13 @@ func TestAccAccessControlResource(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateId:     "MyVDC.MyVapp",
+			},
+			{
+				// Import test
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     "MyVapp",
 			},
 		},
 	})


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes
- Add SharedSetToAccessControl and AccessControlListToSharedSet functions to common/acl
- Use it in vapp_acl
- Uniformise vapp_acl and vdc_acl
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested
```
❯ TF_ACC=1 go test -run TestAccACLResource -v -count=1 ./internal/tests/vapp
=== RUN   TestAccACLResource
--- PASS: TestAccACLResource (10.38s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/vapp        10.384s
❯ TF_ACC=1 go test -run TestAccACLResource -v -count=1 ./internal/tests/vdc 
=== RUN   TestAccACLResource
--- PASS: TestAccACLResource (9.26s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/vdc 9.268s
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->