### PR TITLE
fix(edgegw): test vdc existance before create 

### DIFF
--- a/docs/resources/edgegateway.md
+++ b/docs/resources/edgegateway.md
@@ -15,8 +15,8 @@ The Edge Gateway resource allows you to create and delete Edge Gateways in Cloud
 data "cloudavenue_tier0_vrfs" "example_with_vdc" {}
 
 resource "cloudavenue_edgegateway" "example_with_vdc" {
-  owner_name     = "MyVdc"
-  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example.names.0
+  owner_name     = "MyVDC"
+  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example_with_vdc.names.0
   owner_type     = "vdc"
 }
 
@@ -24,7 +24,7 @@ data "cloudavenue_tier0_vrfs" "example_with_group" {}
 
 resource "cloudavenue_edgegateway" "example_with_group" {
   owner_name     = "MyVDCGroup"
-  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example.names.0
+  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example_with_group.names.0
   owner_type     = "vdc-group"
 }
 ```

--- a/docs/resources/vapp_org_network.md
+++ b/docs/resources/vapp_org_network.md
@@ -15,9 +15,9 @@ Provides capability to attach an existing Org VDC Network to a vApp and toggle n
 data "cloudavenue_tier0_vrfs" "example" {}
 
 resource "cloudavenue_edgegateway" "example" {
-  owner_name     = "MyVDCGroup"
+  owner_name     = "MyVDC"
   tier0_vrf_name = data.cloudavenue_tier0_vrfs.example.names.0
-  owner_type     = "vdc-group"
+  owner_type     = "vdc"
 }
 
 resource "cloudavenue_network_routed" "example" {

--- a/examples/resources/cloudavenue_edgegateway/resource.tf
+++ b/examples/resources/cloudavenue_edgegateway/resource.tf
@@ -1,8 +1,8 @@
 data "cloudavenue_tier0_vrfs" "example_with_vdc" {}
 
 resource "cloudavenue_edgegateway" "example_with_vdc" {
-  owner_name     = "MyVdc"
-  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example.names.0
+  owner_name     = "MyVDC"
+  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example_with_vdc.names.0
   owner_type     = "vdc"
 }
 
@@ -10,6 +10,6 @@ data "cloudavenue_tier0_vrfs" "example_with_group" {}
 
 resource "cloudavenue_edgegateway" "example_with_group" {
   owner_name     = "MyVDCGroup"
-  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example.names.0
+  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example_with_group.names.0
   owner_type     = "vdc-group"
 }

--- a/examples/resources/cloudavenue_vapp_org_network/resource.tf
+++ b/examples/resources/cloudavenue_vapp_org_network/resource.tf
@@ -1,9 +1,9 @@
 data "cloudavenue_tier0_vrfs" "example" {}
 
 resource "cloudavenue_edgegateway" "example" {
-  owner_name     = "MyVDCGroup"
+  owner_name     = "MyVDC"
   tier0_vrf_name = data.cloudavenue_tier0_vrfs.example.names.0
-  owner_type     = "vdc-group"
+  owner_type     = "vdc"
 }
 
 resource "cloudavenue_network_routed" "example" {

--- a/internal/provider/edgegw/edgegateway_resource.go
+++ b/internal/provider/edgegw/edgegateway_resource.go
@@ -220,6 +220,13 @@ func (r *edgeGatewaysResource) Create(
 
 	switch plan.OwnerType.ValueString() {
 	case "vdc":
+		// Check if vDC exist
+		if _, _, err := r.client.GetOrgAndVDC(r.client.GetOrg(), plan.OwnerName.ValueString()); err != nil {
+			resp.Diagnostics.AddError("Error retrieving VDC", err.Error())
+			return
+		}
+
+		// Create Edge Gateway
 		job, httpR, err = r.client.APIClient.EdgeGatewaysApi.CreateVdcEdge(
 			auth,
 			body,
@@ -235,6 +242,18 @@ func (r *edgeGatewaysResource) Create(
 			}
 		}
 	case "vdc-group":
+		// Check if vDC Group exist
+		adminOrg, err := r.client.Vmware.GetAdminOrgByNameOrId(r.client.GetOrg())
+		if err != nil {
+			resp.Diagnostics.AddError("Error retrieving Org", err.Error())
+			return
+		}
+		if _, err := adminOrg.GetVdcGroupByName(plan.OwnerName.ValueString()); err != nil {
+			resp.Diagnostics.AddError("Error retrieving vDC Group", err.Error())
+			return
+		}
+
+		// Create Edge Gateway
 		job, httpR, err = r.client.APIClient.EdgeGatewaysApi.CreateVdcGroupEdge(
 			auth,
 			body,

--- a/internal/tests/vapp/org_network_resource_test.go
+++ b/internal/tests/vapp/org_network_resource_test.go
@@ -14,9 +14,9 @@ const testAccOrgNetworkResourceConfig = `
 data "cloudavenue_tier0_vrfs" "example" {}
 
 resource "cloudavenue_edgegateway" "example" {
-  owner_name     = "MyVDCGroup"
+  owner_name     = "MyVDC"
   tier0_vrf_name = data.cloudavenue_tier0_vrfs.example.names.0
-  owner_type     = "vdc-group"
+  owner_type     = "vdc"
 }
 
 resource "cloudavenue_network_routed" "example" {


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes
- Test vdc or vdc-group existance before create the edgegateway
- Add better testing
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested
```
❯ TF_ACC=1 go test -v -count=1 ./internal/tests/edgegw -run TestAccEdgeGatewayResource
=== RUN   TestAccEdgeGatewayResource
--- PASS: TestAccEdgeGatewayResource (336.21s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/edgegw      336.219s
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->