### PR TITLE
refactor(network): remove diagnosticError struct and use diag.Diagnostic

### DIFF
--- a/internal/provider/network/routed_resource.go
+++ b/internal/provider/network/routed_resource.go
@@ -205,8 +205,8 @@ func (r *networkRoutedResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	parentEdgeGatewayOwnerID, errGet := getParentEdgeGatewayID(org, plan.EdgeGatewayID.ValueString())
-	if errGet != nil {
-		resp.Diagnostics.AddError(errGet.Summary, errGet.Detail)
+	resp.Diagnostics.Append(errGet)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -349,8 +349,8 @@ func (r *networkRoutedResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	parentEdgeGatewayOwnerID, errGet := getParentEdgeGatewayID(org, plan.EdgeGatewayID.ValueString())
-	if errGet != nil {
-		resp.Diagnostics.AddError(errGet.Summary, errGet.Detail)
+	resp.Diagnostics.Append(errGet)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -453,8 +453,8 @@ func (r *networkRoutedResource) Delete(ctx context.Context, req resource.DeleteR
 	}
 
 	parentEdgeGatewayOwnerID, errGet := getParentEdgeGatewayID(org, state.EdgeGatewayID.ValueString())
-	if errGet != nil {
-		resp.Diagnostics.AddError(errGet.Summary, errGet.Detail)
+	resp.Diagnostics.Append(errGet)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly
