### PR TITLE
feat(vdc): add interface to handle vdc or vdc group

### DIFF
--- a/internal/client/vmware.go
+++ b/internal/client/vmware.go
@@ -2,39 +2,69 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 )
 
+var (
+	ErrEmptyOrgNameProvided = errors.New("empty Org name provided")
+	ErrEmptyVDCNameProvided = errors.New("empty VDC name provided")
+	ErrRetrievingOrg        = errors.New("error retrieving Org")
+	ErrRetrievingOrgAdmin   = errors.New("error retrieving Org admin")
+	ErrEmptyOrgFound        = errors.New("empty Org found")
+	ErrRetrievingVDC        = errors.New("error retrieving VDC")
+	ErrRetrievingVDCGroup   = errors.New("error retrieving VDC Group")
+	ErrEmptyVDCFound        = errors.New("empty VDC found")
+)
+
+// VDCOrVDCGroupHandler is an interface to access some common methods on VDC or VDC Group without
+// explicitly handling exact types.
+type VDCOrVDCGroupHandler interface {
+	GetOpenApiOrgVdcNetworkByName(string) (*govcd.OpenApiOrgVdcNetwork, error)
+}
+
 // GetOrgAndVDC finds a pair of org and vdc using the names provided
 // in the args. If the names are empty, it will use the default
 // org and vdc names from the provider.
-func (c *CloudAvenue) GetOrgAndVDC(orgName, vdcName string) (org *govcd.Org, vdc *govcd.Vdc, err error) {
+func (c *CloudAvenue) GetOrgAndVDC(orgName, vdcName string) (org *govcd.Org, vdcOrVDCGroup VDCOrVDCGroupHandler, err error) {
 	if orgName == "" {
-		return nil, nil, fmt.Errorf("empty Org name provided")
+		return nil, nil, fmt.Errorf("%w", ErrEmptyOrgNameProvided)
 	}
 	if vdcName == "" {
-		return nil, nil, fmt.Errorf("empty VDC name provided")
+		return nil, nil, fmt.Errorf("%w", ErrEmptyVDCNameProvided)
 	}
 
 	org, err = c.Vmware.GetOrgByName(orgName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error retrieving Org %s: %w", orgName, err)
+		return nil, nil, fmt.Errorf("%w: %w", ErrRetrievingOrg, err)
 	}
 
 	if org.Org.Name == "" || org.Org.HREF == "" || org.Org.ID == "" {
-		return nil, nil, fmt.Errorf("empty Org %s found ", orgName)
+		return nil, nil, fmt.Errorf("%w : %s", ErrEmptyOrgFound, orgName)
 	}
 
-	vdc, err = org.GetVDCByName(vdcName, false)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error retrieving VDC %s: %w", vdcName, err)
+	vdcOrVDCGroup, err = org.GetVDCByName(vdcName, false)
+	if err != nil && !govcd.ContainsNotFound(err) {
+		return nil, nil, fmt.Errorf("%w: %s %w", ErrRetrievingVDC, vdcName, err)
 	}
 
-	if vdc == nil || vdc.Vdc.ID == "" || vdc.Vdc.HREF == "" || vdc.Vdc.Name == "" {
+	if govcd.ContainsNotFound(err) {
+		var adminOrg *govcd.AdminOrg
+		adminOrg, err = c.Vmware.GetAdminOrgByName(orgName)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%w: %s %w", ErrRetrievingOrgAdmin, vdcName, err)
+		}
+
+		vdcOrVDCGroup, err = adminOrg.GetVdcGroupByName(vdcName)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%w: %s %w", ErrRetrievingVDCGroup, vdcName, err)
+		}
+	}
+	if vdcOrVDCGroup == nil {
 		return nil, nil, fmt.Errorf("error retrieving VDC %s: not found", vdcName)
 	}
 
-	return org, vdc, err
+	return org, vdcOrVDCGroup, err
 }

--- a/internal/provider/common/vapp/vapp.go
+++ b/internal/provider/common/vapp/vapp.go
@@ -71,12 +71,17 @@ Init
 
 Get vApp name or vApp ID.
 */
-func Init(client *client.CloudAvenue, vdc vdc.VDC, vappID, vappName types.String) (vapp VApp, d diag.Diagnostics) {
+func Init(_ *client.CloudAvenue, vdcHandler vdc.VDC, vappID, vappName types.String) (vapp VApp, d diag.Diagnostics) {
 	var vappNameID string
 	if vappID.IsNull() || vappID.IsUnknown() {
 		vappNameID = vappName.ValueString()
 	} else {
 		vappNameID = vappID.ValueString()
+	}
+
+	vdc, errGetVDC := vdcHandler.GetVDC()
+	if errGetVDC.HasError() {
+		return
 	}
 
 	// Request vApp
@@ -89,7 +94,7 @@ func Init(client *client.CloudAvenue, vdc vdc.VDC, vappID, vappName types.String
 		d.AddError("Error retrieving vApp", err.Error())
 		return
 	}
-	return VApp{VApp: vappOut, vdc: vdc}, nil
+	return VApp{VApp: vappOut, vdc: vdcHandler}, nil
 }
 
 // LockParentVApp locks the parent vApp.

--- a/internal/provider/network/routed_resource.go
+++ b/internal/provider/network/routed_resource.go
@@ -492,7 +492,7 @@ func (r *networkRoutedResource) ImportState(ctx context.Context, req resource.Im
 
 	vdcOrVDCGroupName, networkName := resourceURI[0], resourceURI[1]
 
-	org, vdc, err := r.client.GetOrgAndVDC(r.client.GetOrg(), r.client.GetDefaultVDC())
+	_, vdc, err := r.client.GetOrgAndVDC(r.client.GetOrg(), vdcOrVDCGroupName)
 	if err != nil && govcd.ContainsNotFound(err) {
 		resp.Diagnostics.AddError("Error retrieving VDC", err.Error())
 		return
@@ -505,21 +505,8 @@ func (r *networkRoutedResource) ImportState(ctx context.Context, req resource.Im
 	}
 
 	if orgNetwork == nil {
-		adminOrg, err := r.client.Vmware.GetAdminOrgByName(org.Org.Name)
-		if err != nil {
-			resp.Diagnostics.AddError("Error retrieving Admin Org", err.Error())
-			return
-		}
-		vdcgroup, err := adminOrg.GetVdcGroupByName(vdcOrVDCGroupName)
-		if err != nil {
-			resp.Diagnostics.AddError("Error retrieving VDC group", err.Error())
-			return
-		}
-		orgNetwork, err = vdcgroup.GetOpenApiOrgVdcNetworkByName(networkName)
-		if err != nil && govcd.ContainsNotFound(err) {
-			resp.Diagnostics.AddError("Error retrieving org vdc_group network by name", err.Error())
-			return
-		}
+		resp.Diagnostics.AddError("Error retrieving org network by name", err.Error())
+		return
 	}
 
 	if !orgNetwork.IsRouted() {

--- a/internal/provider/vapp/org_network_resource.go
+++ b/internal/provider/vapp/org_network_resource.go
@@ -152,8 +152,14 @@ func (r *orgNetworkResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 	defer r.vapp.UnlockParentVApp(ctx)
 
+	vdc, errGetVDC := r.vdc.GetVDC()
+	resp.Diagnostics.Append(errGetVDC...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	orgNetworkName := plan.NetworkName.ValueString()
-	orgNetwork, err := r.vdc.GetOrgVdcNetworkByNameOrId(orgNetworkName, true)
+	orgNetwork, err := vdc.GetOrgVdcNetworkByNameOrId(orgNetworkName, true)
 	if err != nil {
 		resp.Diagnostics.AddError("Error retrieving org network", err.Error())
 		return

--- a/internal/provider/vapp/vapp_resource.go
+++ b/internal/provider/vapp/vapp_resource.go
@@ -200,7 +200,13 @@ func (r *vappResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
-	vapp, err := r.vdc.CreateRawVApp(plan.VAppName.ValueString(), plan.Description.ValueString())
+	vdc, errGetVDC := r.vdc.GetVDC()
+	resp.Diagnostics.Append(errGetVDC...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	vapp, err := vdc.CreateRawVApp(plan.VAppName.ValueString(), plan.Description.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error creating vApp", err.Error())
 		return
@@ -318,7 +324,7 @@ func (r *vappResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Request vApp
-	vappRefreshed, err := r.vdc.GetVAppByNameOrId(vapp.VApp.ID, true)
+	vappRefreshed, err := vdc.GetVAppByNameOrId(vapp.VApp.ID, true)
 	if err != nil {
 		if errors.Is(err, govcd.ErrorEntityNotFound) {
 			resp.Diagnostics.AddError("vApp not found after creating", err.Error())
@@ -472,9 +478,14 @@ func (r *vappResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	vdc, errGetVDC := r.vdc.GetVDC()
+	resp.Diagnostics.Append(errGetVDC...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Request vApp
-	vapp, err := r.vdc.GetVAppByNameOrId(state.VAppID.ValueString(), true)
+	vapp, err := vdc.GetVAppByNameOrId(state.VAppID.ValueString(), true)
 	if err != nil {
 		if errors.Is(err, govcd.ErrorEntityNotFound) {
 			resp.Diagnostics.AddError("vApp not found", err.Error())
@@ -579,7 +590,7 @@ func (r *vappResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// Request vApp
-	vappRefreshed, err := r.vdc.GetVAppByNameOrId(state.VAppID.ValueString(), true)
+	vappRefreshed, err := vdc.GetVAppByNameOrId(state.VAppID.ValueString(), true)
 	if err != nil {
 		if errors.Is(err, govcd.ErrorEntityNotFound) {
 			resp.Diagnostics.AddError("vApp not found after creating", err.Error())
@@ -649,8 +660,14 @@ func (r *vappResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		return
 	}
 
+	vdc, errGetVDC := r.vdc.GetVDC()
+	resp.Diagnostics.Append(errGetVDC...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Request vApp
-	vapp, err := r.vdc.GetVAppByNameOrId(state.VAppID.ValueString(), true)
+	vapp, err := vdc.GetVAppByNameOrId(state.VAppID.ValueString(), true)
 	if err != nil {
 		if errors.Is(err, govcd.ErrorEntityNotFound) {
 			resp.Diagnostics.AddError("vApp not found", err.Error())

--- a/internal/provider/vm/common_vm.go
+++ b/internal/provider/vm/common_vm.go
@@ -218,7 +218,7 @@ func isForcedCustomization(v *Client) bool {
 //
 // If `vm_name_in_template` was not specified:
 // * Return error.
-func lookupvAppTemplateforVM(v *Client, _ *govcd.Org, _ *govcd.Vdc) (govcd.VAppTemplate, error) {
+func lookupvAppTemplateforVM(v *Client, _ *govcd.Org, _ client.VDCOrVDCGroupHandler) (govcd.VAppTemplate, error) {
 	if !v.Plan.VappTemplateID.IsNull() && !v.Plan.VappTemplateID.IsUnknown() {
 		// Lookup of vApp Template using URN
 
@@ -375,10 +375,15 @@ func isItVappNetwork(vAppNetworkName string, vapp govcd.VApp) (bool, error) {
 	return false, fmt.Errorf("configured vApp network isn't found: %s", vAppNetworkName)
 }
 
-func lookupStorageProfile(storageProfileName string, vdc *govcd.Vdc) (*govcdtypes.Reference, error) {
+func lookupStorageProfile(storageProfileName string, vdcHandler client.VDCOrVDCGroupHandler) (*govcdtypes.Reference, error) {
 	// If no storage profile lookup was requested - bail out early and return nil reference
 	if storageProfileName == "" {
 		return nil, errors.New("storageProfileName is an empty string")
+	}
+
+	vdc, isVDC := vdcHandler.(*govcd.Vdc)
+	if !isVDC {
+		return nil, fmt.Errorf("expected *govcd.Vdc type, have %T", vdcHandler)
 	}
 
 	storageProfile, err := vdc.FindStorageProfileReference(storageProfileName)

--- a/internal/provider/vm/common_vm_create.go
+++ b/internal/provider/vm/common_vm_create.go
@@ -29,7 +29,6 @@ import (
 // Note. VM Power ON (if it wasn't disabled in HCL configuration) occurs as last step after all configuration is done.
 func createVM(_ context.Context, v *Client) (vm *govcd.VM, err error) { //nolint:gocyclo
 	var (
-		vdc        *govcd.Vdc
 		org        *govcd.Org
 		vapp       *govcd.VApp
 		vmTemplate govcd.VAppTemplate
@@ -45,9 +44,14 @@ func createVM(_ context.Context, v *Client) (vm *govcd.VM, err error) { //nolint
 	}
 
 	// Get vcd object
-	org, vdc, err = v.Client.GetOrgAndVDC(v.Client.GetOrg(), v.Plan.VDC.ValueString())
+	org, vdcHandler, err := v.Client.GetOrgAndVDC(v.Client.GetOrg(), v.Plan.VDC.ValueString())
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving VDC %s: %w", v.Plan.VDC.ValueString(), err)
+	}
+
+	vdc, isVDC := vdcHandler.(*govcd.Vdc)
+	if !isVDC {
+		return nil, fmt.Errorf("expected *govcd.Vdc type, have %T", vdcHandler)
 	}
 
 	if !v.Plan.VappTemplateID.IsNull() && !v.Plan.VappTemplateID.IsUnknown() {

--- a/internal/provider/vm/common_vm_read.go
+++ b/internal/provider/vm/common_vm_read.go
@@ -26,9 +26,14 @@ func readVM(v *Client) (*govcd.VM, error) {
 	}
 
 	// Get vcd object
-	_, vdc, err = v.Client.GetOrgAndVDC(v.Client.GetOrg(), v.State.VDC.ValueString())
+	_, vdcHandler, err := v.Client.GetOrgAndVDC(v.Client.GetOrg(), v.State.VDC.ValueString())
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving VDC %s: %w", v.State.VDC.ValueString(), err)
+	}
+
+	vdc, isVDC := vdcHandler.(*govcd.Vdc)
+	if !isVDC {
+		return nil, fmt.Errorf("expected *govcd.Vdc type, have %T", vdcHandler)
 	}
 
 	// Get vApp

--- a/internal/provider/vm/common_vm_update.go
+++ b/internal/provider/vm/common_vm_update.go
@@ -30,9 +30,14 @@ func updateVM(ctx context.Context, v *Client) (*govcd.VM, error) { //nolint:gocy
 	}
 
 	// Get vcd object
-	_, vdc, err = v.Client.GetOrgAndVDC(v.Client.GetOrg(), v.Plan.VDC.ValueString())
+	_, vdcHandler, err := v.Client.GetOrgAndVDC(v.Client.GetOrg(), v.Plan.VDC.ValueString())
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving VDC %s: %w", v.Plan.VDC.ValueString(), err)
+	}
+
+	vdc, isVDC := vdcHandler.(*govcd.Vdc)
+	if !isVDC {
+		return nil, fmt.Errorf("expected *govcd.Vdc type, have %T", vdcHandler)
 	}
 
 	// Get vApp

--- a/internal/provider/vm/vm_resource.go
+++ b/internal/provider/vm/vm_resource.go
@@ -352,12 +352,17 @@ func (r *vmResource) Delete(ctx context.Context, req resource.DeleteRequest, res
 	}
 
 	// Get vcd object
-	_, vdc, err := r.client.GetOrgAndVDC(r.client.GetOrg(), state.VDC.ValueString())
+	_, vdcHandler, err := r.client.GetOrgAndVDC(r.client.GetOrg(), state.VDC.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error retrieving VDC", err.Error())
 		return
 	}
 
+	vdc, isVDC := vdcHandler.(*govcd.Vdc)
+	if !isVDC {
+		resp.Diagnostics.AddError(fmt.Sprintf("Expected *govcd.Vdc, got %T", vdcHandler), err.Error())
+		return
+	}
 	// Get vApp
 	vapp, err := vdc.GetVAppByName(state.VappName.ValueString(), true)
 	if err != nil {


### PR DESCRIPTION
Tests OK :
```
❯ TF_ACC=1 go test -v -count=1  -run TestAccNetworkRoutedResource  ./internal/tests/network
=== RUN   TestAccNetworkRoutedResource
--- PASS: TestAccNetworkRoutedResource (79.22s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/network     79.623s
```


```
❯ TF_ACC=1 go test -v -count=1  -run TestAccVappResource  ./internal/tests/vapp
=== RUN   TestAccVappResource
--- PASS: TestAccVappResource (21.66s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/vapp        22.099s
```
