### PR TITLE
fix(network): cloudavenue_network_routed error on import

### DIFF
--- a/docs/resources/network_routed.md
+++ b/docs/resources/network_routed.md
@@ -17,10 +17,40 @@ data "cloudavenue_edgegateway" "example" {
 }
 
 resource "cloudavenue_network_routed" "example" {
-  name        = "OrgNetExample"
+  name        = "OrgNetExampleOnVDCGroup"
   description = "Org Net Example"
 
   edge_gateway_id = data.cloudavenue_edgegateway.example.id
+
+  gateway       = "192.168.1.254"
+  prefix_length = 24
+
+  dns1 = "1.1.1.1"
+  dns2 = "8.8.8.8"
+
+  dns_suffix = "example"
+
+  static_ip_pool = [
+    {
+      start_address = "192.168.1.10"
+      end_address   = "192.168.1.20"
+    }
+  ]
+}
+
+data "cloudavenue_tier0_vrfs" "example_with_vdc" {}
+
+resource "cloudavenue_edgegateway" "example_with_vdc" {
+  owner_name     = "MyVDC"
+  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example_with_vdc.names.0
+  owner_type     = "vdc"
+}
+
+resource "cloudavenue_network_routed" "example" {
+  name        = "OrgNetExampleOnVDC"
+  description = "Org Net Example"
+
+  edge_gateway_id = cloudavenue_edgegateway.example_with_vdc.id
 
   gateway       = "192.168.1.254"
   prefix_length = 24

--- a/examples/resources/cloudavenue_network_routed/resource.tf
+++ b/examples/resources/cloudavenue_network_routed/resource.tf
@@ -3,10 +3,40 @@ data "cloudavenue_edgegateway" "example" {
 }
 
 resource "cloudavenue_network_routed" "example" {
-  name        = "OrgNetExample"
+  name        = "OrgNetExampleOnVDCGroup"
   description = "Org Net Example"
 
   edge_gateway_id = data.cloudavenue_edgegateway.example.id
+
+  gateway       = "192.168.1.254"
+  prefix_length = 24
+
+  dns1 = "1.1.1.1"
+  dns2 = "8.8.8.8"
+
+  dns_suffix = "example"
+
+  static_ip_pool = [
+    {
+      start_address = "192.168.1.10"
+      end_address   = "192.168.1.20"
+    }
+  ]
+}
+
+data "cloudavenue_tier0_vrfs" "example_with_vdc" {}
+
+resource "cloudavenue_edgegateway" "example_with_vdc" {
+  owner_name     = "MyVDC"
+  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example_with_vdc.names.0
+  owner_type     = "vdc"
+}
+
+resource "cloudavenue_network_routed" "example" {
+  name        = "OrgNetExampleOnVDC"
+  description = "Org Net Example"
+
+  edge_gateway_id = cloudavenue_edgegateway.example_with_vdc.id
 
   gateway       = "192.168.1.254"
   prefix_length = 24

--- a/internal/provider/network/routed_resource.go
+++ b/internal/provider/network/routed_resource.go
@@ -97,6 +97,7 @@ func (r *networkRoutedResource) Schema(ctx context.Context, _ resource.SchemaReq
 				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 				MarkdownDescription: "Edge gateway ID in which Routed network should be located.",
 			},
@@ -497,8 +498,6 @@ func (r *networkRoutedResource) ImportState(ctx context.Context, req resource.Im
 		resp.Diagnostics.AddError("Error retrieving VDC", err.Error())
 		return
 	}
-
-	// _, vdc, err := r.client.GetOrgAndVDC(r.client.GetOrg(), vdcOrVDCGroupName)
 
 	orgNetwork, err := v.GetOpenApiOrgVdcNetworkByName(networkName)
 	if err != nil && !govcd.ContainsNotFound(err) {


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

```
❯ TF_ACC=1 go test -v -count=1  -run TestAccNetworkRoutedResource  ./internal/tests/network
=== RUN   TestAccNetworkRoutedResource
--- PASS: TestAccNetworkRoutedResource (225.85s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/network     226.408s
```