### PR TITLE
refactor: use superschema for the vm_affinity_rule resource

### DIFF
--- a/docs/resources/vm_affinity_rule.md
+++ b/docs/resources/vm_affinity_rule.md
@@ -30,7 +30,7 @@ resource "cloudavenue_vm_affinity_rule" "example" {
 
 - `name` (String) VM affinity rule name.
 - `polarity` (String) One of `Affinity`, `Anti-Affinity`
-- `vm_ids` (List of String) Set of VM IDs assigned to this rule.
+- `vm_ids` (List of String) List of VM IDs to apply the affinity rule to.
 
 ### Optional
 

--- a/internal/provider/vm/vm_affinity_rule_schema.go
+++ b/internal/provider/vm/vm_affinity_rule_schema.go
@@ -3,12 +3,11 @@ package vm
 import (
 	"fmt"
 
-	fboolplanmodifier "github.com/FrangipaneTeam/terraform-plugin-framework-planmodifiers/boolplanmodifier"
 	fstringvalidator "github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/path"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	schemaR "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,105 +39,156 @@ type vmAffinityRuleResourceModel struct {
 // 	RuleID   types.String `tfsdk:"rule_id"`
 // }
 
-type vmAffinityRuleSchemaOpts func(*vmAffinityRuleSchemaParams)
-
-type vmAffinityRuleSchemaParams struct {
-	resource   bool
-	datasource bool
-}
-
-// func withDataSource() vmAffinityRuleSchemaOpts {
-// 	return func(params *vmAffinityRuleSchemaParams) {
-// 		params.datasource = true
-// 	}
-// }
-
 /*
 vmAffinityRuleSchema
 This function is used to create the schema for the catalog resource and datasource.
 Default is to create a resource schema.  If you want to create a datasource schema
 you must pass in the withDataSource() option.
 */
-func vmAffinityRuleSchema(opts ...vmAffinityRuleSchemaOpts) superschema.Schema {
-	params := &vmAffinityRuleSchemaParams{}
+func vmAffinityRuleSchema() superschema.Schema {
+	v := vdc.Schema()
 
-	if len(opts) > 0 {
-		for _, opt := range opts {
-			opt(params)
-		}
-	} else {
-		params.resource = true
+	return superschema.Schema{
+		Common: superschema.SchemaDetails{
+			MarkdownDescription: "Provides a Cloud Avenue VM Affinity Rule.",
+		},
+		Resource: superschema.SchemaDetails{
+			MarkdownDescription: " This can be used to create, modify and delete VM affinity and anti-affinity rules.",
+		},
+		DataSource: superschema.SchemaDetails{
+			MarkdownDescription: " This can be used to read VM affinity and anti-affinity rules.",
+		},
+		Attributes: map[string]superschema.Attribute{
+			"id": superschema.StringAttribute{
+				Resource: &schemaR.StringAttribute{
+					MarkdownDescription: "The ID of the affinity rule.",
+					Computed:            true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
+				},
+			},
+			"vdc": superschema.StringAttribute{
+				Resource: &v,
+			},
+			"name": superschema.StringAttribute{
+				Resource: &schemaR.StringAttribute{
+					Required:            true,
+					MarkdownDescription: "VM affinity rule name.",
+				},
+			},
+			"polarity": superschema.StringAttribute{
+				Resource: &schemaR.StringAttribute{
+					Required:            true,
+					MarkdownDescription: fmt.Sprintf("One of `%s`, `%s`", govcdtypes.PolarityAffinity, govcdtypes.PolarityAntiAffinity),
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+					Validators: []validator.String{
+						stringvalidator.OneOf(govcdtypes.PolarityAffinity, govcdtypes.PolarityAntiAffinity),
+					},
+				},
+			},
+			"enabled": superschema.BoolAttribute{
+				Resource: &schemaR.BoolAttribute{
+					Optional:            true,
+					Computed:            true,
+					Default:             booldefault.StaticBool(true),
+					MarkdownDescription: "`True` if this affinity rule is enabled. Default is `true`.",
+				},
+			},
+			"required": superschema.BoolAttribute{
+				Resource: &schemaR.BoolAttribute{
+					Optional: true,
+					Computed: true,
+					Default:  booldefault.StaticBool(true),
+					MarkdownDescription: "`True` if this affinity rule is required. When a rule is mandatory, " +
+						"a host failover will not power on the VM if doing so would violate the rule. Default is `true`.",
+				},
+			},
+			"vm_ids": superschema.ListAttribute{
+				Resource: &schemaR.ListAttribute{
+					Required:            true,
+					ElementType:         types.StringType,
+					MarkdownDescription: "List of VM IDs to apply the affinity rule to.",
+					Validators: []validator.List{
+						listvalidator.SizeAtMost(2),
+						listvalidator.ValueStringsAre(fstringvalidator.IsURN()),
+					},
+				},
+			},
+		},
 	}
 
-	_schema := superschema.Schema{}
-	_schema.Attributes = map[string]schema.Attribute{
-		"id": schema.StringAttribute{
-			Computed:            true,
-			MarkdownDescription: "The ID of the affinity rule.",
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
-			},
-		},
-		"vdc": vdc.Schema(),
-		"name": schema.StringAttribute{
-			Required:            true,
-			MarkdownDescription: "VM affinity rule name.",
-		},
-		"polarity": schema.StringAttribute{
-			Required:            true,
-			MarkdownDescription: fmt.Sprintf("One of `%s`, `%s`", govcdtypes.PolarityAffinity, govcdtypes.PolarityAntiAffinity),
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.RequiresReplace(),
-			},
-			Validators: []validator.String{
-				stringvalidator.OneOf(govcdtypes.PolarityAffinity, govcdtypes.PolarityAntiAffinity),
-			},
-		},
-		"required": schema.BoolAttribute{
-			Optional: true,
-			Computed: true,
-			MarkdownDescription: "`True` if this affinity rule is required. When a rule is mandatory, " +
-				"a host failover will not power on the VM if doing so would violate the rule. Default is `true`.",
-			PlanModifiers: []planmodifier.Bool{
-				fboolplanmodifier.SetDefault(true),
-			},
-		},
-		"enabled": schema.BoolAttribute{
-			Optional:            true,
-			Computed:            true,
-			MarkdownDescription: "`True` if this affinity rule is enabled. Default is `true`.",
-			PlanModifiers: []planmodifier.Bool{
-				fboolplanmodifier.SetDefault(true),
-			},
-		},
-		"vm_ids": schema.ListAttribute{
-			Required:            true,
-			ElementType:         types.StringType,
-			MarkdownDescription: "Set of VM IDs assigned to this rule.",
-			Validators: []validator.List{
-				listvalidator.SizeAtMost(2),
-				listvalidator.ValueStringsAre(fstringvalidator.IsURN()),
-			},
-		},
-	}
+	// _schema := superschema.Schema{}
+	// _schema.Attributes = map[string]schema.Attribute{
+	// 	"id": schema.StringAttribute{
+	// 		Computed:            true,
+	// 		MarkdownDescription: "The ID of the affinity rule.",
+	// 		PlanModifiers: []planmodifier.String{
+	// 			stringplanmodifier.UseStateForUnknown(),
+	// 		},
+	// 	},
+	// 	"vdc": vdc.Schema(),
+	// 	"name": schema.StringAttribute{
+	// 		Required:            true,
+	// 		MarkdownDescription: "VM affinity rule name.",
+	// 	},
+	// 	"polarity": schema.StringAttribute{
+	// 		Required:            true,
+	// 		MarkdownDescription: fmt.Sprintf("One of `%s`, `%s`", govcdtypes.PolarityAffinity, govcdtypes.PolarityAntiAffinity),
+	// 		PlanModifiers: []planmodifier.String{
+	// 			stringplanmodifier.RequiresReplace(),
+	// 		},
+	// 		Validators: []validator.String{
+	// 			stringvalidator.OneOf(govcdtypes.PolarityAffinity, govcdtypes.PolarityAntiAffinity),
+	// 		},
+	// 	},
+	// 	"required": schema.BoolAttribute{
+	// 		Optional: true,
+	// 		Computed: true,
+	// 		MarkdownDescription: "`True` if this affinity rule is required. When a rule is mandatory, " +
+	// 			"a host failover will not power on the VM if doing so would violate the rule. Default is `true`.",
+	// 		PlanModifiers: []planmodifier.Bool{
+	// 			fboolplanmodifier.SetDefault(true),
+	// 		},
+	// 	},
+	// 	"enabled": schema.BoolAttribute{
+	// 		Optional:            true,
+	// 		Computed:            true,
+	// 		MarkdownDescription: "`True` if this affinity rule is enabled. Default is `true`.",
+	// 		PlanModifiers: []planmodifier.Bool{
+	// 			fboolplanmodifier.SetDefault(true),
+	// 		},
+	// 	},
+	// 	"vm_ids": schema.ListAttribute{
+	// 		Required:            true,
+	// 		ElementType:         types.StringType,
+	// 		MarkdownDescription: "Set of VM IDs assigned to this rule.",
+	// 		Validators: []validator.List{
+	// 			listvalidator.SizeAtMost(2),
+	// 			listvalidator.ValueStringsAre(fstringvalidator.IsURN()),
+	// 		},
+	// 	},
+	// }
 
-	if params.datasource {
-		_schema.MarkdownDescription = "Provides a Cloud Avenue VM Affinity Rule. This can be used to read VM affinity and anti-affinity rules."
-		// set computed for all attributes
-		_schema = _schema.SetParam(superschema.Computed)
+	// if params.datasource {
+	// 	_schema.MarkdownDescription = "Provides a Cloud Avenue VM Affinity Rule. This can be used to read VM affinity and anti-affinity rules."
+	// 	// set computed for all attributes
+	// 	_schema = _schema.SetParam(superschema.Computed)
 
-		_schema.Attributes["rule_id"] = schema.StringAttribute{
-			Optional:            true,
-			MarkdownDescription: "VM affinity rule ID. It's the preferred way of identifying a rule.",
-			Validators: []validator.String{
-				stringvalidator.ExactlyOneOf(path.MatchRoot("name"), path.MatchRoot("rule_id")),
-			},
-		}
-	}
+	// 	_schema.Attributes["rule_id"] = schema.StringAttribute{
+	// 		Optional:            true,
+	// 		MarkdownDescription: "VM affinity rule ID. It's the preferred way of identifying a rule.",
+	// 		Validators: []validator.String{
+	// 			stringvalidator.ExactlyOneOf(path.MatchRoot("name"), path.MatchRoot("rule_id")),
+	// 		},
+	// 	}
+	// }
 
-	if params.resource {
-		_schema.MarkdownDescription = "Provides a Cloud Avenue VM Affinity Rule. This can be used to create, modify and delete VM affinity and anti-affinity rules."
-	}
+	// if params.resource {
+	// 	_schema.MarkdownDescription = "Provides a Cloud Avenue VM Affinity Rule. This can be used to create, modify and delete VM affinity and anti-affinity rules."
+	// }
 
-	return _schema
+	// return _schema
 }


### PR DESCRIPTION
### Description of your changes

Fixe #207 

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
TF_ACC=1 go test -v -count=1  -run TestAccVmAffinityRuleResource  ./internal/tests/vm
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/vm  41.814s
```