### PR TITLE
chore: Add lock/unlock for customer API

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,11 +17,6 @@ Documentation regarding Data Sources and Resources can be found in the sidebar t
 
 Cloud Avenue support authentication with username, password and organization.
 
-## Known Limitations
-
-Because of the way Cloud Avenue API works, it is not possible to work on many resources at the same time.
-This means that if you have a Terraform configuration with multiple resources, you will need to run `terraform apply -parallelism=1` or `terraform destroy -parallelism=1`.
-
 ## Example Usage
 
 ```terraform

--- a/internal/provider/common/cloudavenue/cloudavenue.go
+++ b/internal/provider/common/cloudavenue/cloudavenue.go
@@ -1,0 +1,23 @@
+package cloudavenue
+
+import (
+	"context"
+
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/mutex"
+)
+
+var cAMutexKV = mutex.NewKV()
+
+const keyLock = "cloudavenue:customer:api:lock"
+
+// Lock
+// lock call to the cloudavenue customer API.
+func Lock(ctx context.Context) {
+	cAMutexKV.KvLock(ctx, keyLock)
+}
+
+// Unlock
+// unlock call to the cloudavenue customer API.
+func Unlock(ctx context.Context) {
+	cAMutexKV.KvUnlock(ctx, keyLock)
+}

--- a/internal/provider/edgegw/edgegateway_resource.go
+++ b/internal/provider/edgegw/edgegateway_resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/client"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common"
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/cloudavenue"
 )
 
 const (
@@ -214,6 +215,9 @@ func (r *edgeGatewaysResource) Create(
 		Tier0VrfId:          plan.Tier0VrfID.ValueString(),
 		EnableLoadBalancing: plan.EnableLoadBalancing.ValueBool(),
 	}
+
+	cloudavenue.Lock(ctx)
+	defer cloudavenue.Unlock(ctx)
 
 	var err error
 	var job apiclient.Jobcreated
@@ -468,6 +472,9 @@ func (r *edgeGatewaysResource) Delete(
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	cloudavenue.Lock(ctx)
+	defer cloudavenue.Unlock(ctx)
 
 	// Delete timeout
 	deleteTimeout, errTO := state.Timeouts.Delete(ctx, 8*time.Minute)

--- a/internal/provider/publicip/publicip_resource.go
+++ b/internal/provider/publicip/publicip_resource.go
@@ -26,6 +26,7 @@ import (
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/client"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common"
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/cloudavenue"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -167,6 +168,9 @@ func (r *publicIPResource) Create(ctx context.Context, req resource.CreateReques
 		)
 		return
 	}
+
+	cloudavenue.Lock(ctx)
+	defer cloudavenue.Unlock(ctx)
 
 	// if edge_id is provided, get edge_name
 	if !plan.EdgeID.IsNull() {
@@ -424,6 +428,9 @@ func (r *publicIPResource) Delete(ctx context.Context, req resource.DeleteReques
 		)
 		return
 	}
+
+	cloudavenue.Lock(ctx)
+	defer cloudavenue.Unlock(ctx)
 
 	// Delete the public IP
 	job, httpR, err := r.client.APIClient.PublicIPApi.DeletePublicIP(ctx, state.PublicIP.ValueString())

--- a/internal/provider/vcda/vcda_ip_resource.go
+++ b/internal/provider/vcda/vcda_ip_resource.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/client"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers"
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/cloudavenue"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -104,6 +105,9 @@ func (r *vcdaIPResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
+	cloudavenue.Lock(ctx)
+	defer cloudavenue.Unlock(ctx)
+
 	// Call API to create the resource and check for errors.
 	_, httpR, err := r.client.APIClient.VCDAApi.CreateVcdaIP(r.client.Auth, plan.IPAddress.ValueString())
 	if httpR != nil {
@@ -184,6 +188,9 @@ func (r *vcdaIPResource) Delete(ctx context.Context, req resource.DeleteRequest,
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	cloudavenue.Lock(ctx)
+	defer cloudavenue.Unlock(ctx)
 
 	// Call API to delete the resource and check for errors.
 	_, httpR, err := r.client.APIClient.VCDAApi.DeleteVcdaIP(r.client.Auth, state.IPAddress.ValueString())

--- a/internal/provider/vdc/vdc_resource.go
+++ b/internal/provider/vdc/vdc_resource.go
@@ -28,6 +28,7 @@ import (
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/client"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common"
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/cloudavenue"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -282,6 +283,9 @@ func (r *vdcResource) Create(ctx context.Context, req resource.CreateRequest, re
 	var job apiclient.Jobcreated
 	var httpR *http.Response
 
+	cloudavenue.Lock(ctx)
+	defer cloudavenue.Unlock(ctx)
+
 	// Call API to create the resource and test for errors.
 	job, httpR, err = r.client.APIClient.VDCApi.CreateOrgVdc(auth, body)
 
@@ -515,6 +519,9 @@ func (r *vdcResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	var job apiclient.Jobcreated
 	var httpR *http.Response
 
+	cloudavenue.Lock(ctx)
+	defer cloudavenue.Unlock(ctx)
+
 	// Call API to update the resource and test for errors.
 	job, httpR, err = r.client.APIClient.VDCApi.UpdateOrgVdc(auth, body, body.Vdc.Name)
 
@@ -588,6 +595,9 @@ func (r *vdcResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		)
 		return
 	}
+
+	cloudavenue.Lock(ctx)
+	defer cloudavenue.Unlock(ctx)
 
 	// Delete the VDC
 	job, httpR, err := r.client.APIClient.VDCApi.DeleteOrgVdc(auth, state.Name.ValueString())

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -17,11 +17,6 @@ Documentation regarding Data Sources and Resources can be found in the sidebar t
 
 Cloud Avenue support authentication with username, password and organization.
 
-## Known Limitations
-
-Because of the way Cloud Avenue API works, it is not possible to work on many resources at the same time.
-This means that if you have a Terraform configuration with multiple resources, you will need to run `terraform apply -parallelism=1` or `terraform destroy -parallelism=1`.
-
 ## Example Usage
 
 {{ tffile .ExampleFile }}


### PR DESCRIPTION
### Description of your changes

Fixe #211 

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
cloudavenue_edgegateway.example_with_vdc: Creating...
cloudavenue_vdc.example: Creating...
cloudavenue_vdc.example: Still creating... [10s elapsed]
cloudavenue_edgegateway.example_with_vdc: Still creating... [10s elapsed]
cloudavenue_edgegateway.example_with_vdc: Still creating... [20s elapsed]
cloudavenue_vdc.example: Still creating... [20s elapsed]
cloudavenue_vdc.example: Still creating... [30s elapsed]
cloudavenue_edgegateway.example_with_vdc: Still creating... [30s elapsed]
cloudavenue_vdc.example: Still creating... [40s elapsed]
cloudavenue_edgegateway.example_with_vdc: Still creating... [40s elapsed]
cloudavenue_vdc.example: Still creating... [50s elapsed]
cloudavenue_edgegateway.example_with_vdc: Still creating... [50s elapsed]
cloudavenue_edgegateway.example_with_vdc: Still creating... [1m0s elapsed]
cloudavenue_vdc.example: Still creating... [1m0s elapsed]
cloudavenue_vdc.example: Still creating... [1m10s elapsed]
cloudavenue_edgegateway.example_with_vdc: Still creating... [1m10s elapsed]
cloudavenue_edgegateway.example_with_vdc: Still creating... [1m20s elapsed]
cloudavenue_vdc.example: Still creating... [1m20s elapsed]
cloudavenue_vdc.example: Still creating... [1m30s elapsed]
cloudavenue_edgegateway.example_with_vdc: Still creating... [1m30s elapsed]
cloudavenue_edgegateway.example_with_vdc: Creation complete after 1m30s [id=urn:vcloud:gateway:5c03ff7f-e9a7-4e17-b9a5-ddf5cf724b1e]
cloudavenue_vdc.example: Still creating... [1m40s elapsed]
cloudavenue_vdc.example: Still creating... [1m50s elapsed]
cloudavenue_vdc.example: Still creating... [2m0s elapsed]
cloudavenue_vdc.example: Creation complete after 2m2s [id=urn:vcloud:vdc:c49ae920-b3cc-446c-a54d-ae422be23011]

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

----- 

go test -v -count=1  -run TestAccVDCResource  ./internal/tests/vdc
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/vdc 87.961s
```