### PR TITLE
ci: fix generate-changelog

### DIFF
--- a/.ci/scripts/release-note.tmpl
+++ b/.ci/scripts/release-note.tmpl
@@ -1,9 +1,3 @@
 {{- define "note" -}}
-{{- if eq "new-resource" .Type -}}
-* **New Resource:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/{{- .Issue -}}))
-{{- else if eq "new-data-source" .Type -}}
-* **New Data Source:** `{{.Body}}` ([#{{- .Issue -}}](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/{{- .Issue -}}))
-{{- else -}}
-* {{.Body}} ([#{{- .Issue -}}](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/{{- .Issue -}}))
-{{- end -}}
+{{if eq "new-resource" .Type}}**New Resource:** {{else if eq "new-data-source" .Type}}**New Data Source:** {{ end }}{{.Body}} ([GH-{{- .Issue -}}](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/{{- .Issue -}}))
 {{- end -}}

--- a/.github/workflows/dapendabot_changelog.yml
+++ b/.github/workflows/dapendabot_changelog.yml
@@ -1,0 +1,35 @@
+name: Add CHANGELOG for dependabot changes
+on: pull_request_target
+permissions:
+  pull-requests: write
+  issues: write
+  repository-projects: write
+  contents: write
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.3.6
+      - uses: actions/checkout@v3
+      - run: |
+          gh pr checkout $PR_URL
+          cat << EOF > .changelog/$PR_NUMBER.txt
+          \`\`\`release-note:dependency
+          deps: bumps $DEP_NAME from $DEP_PREV_VERSION to $DEP_NEXT_VERSION
+          \`\`\`
+          EOF
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+          git add .changelog/$PR_NUMBER.txt
+          git commit -m "add CHANGELOG for #$PR_NUMBER"
+          git push
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DEP_NAME: ${{ steps.dependabot-metadata.outputs.dependency-names }}
+          DEP_PREV_VERSION: ${{ steps.dependabot-metadata.outputs.previous-version }}
+          DEP_NEXT_VERSION: ${{ steps.dependabot-metadata.outputs.new-version }}

--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -20,9 +20,9 @@ jobs:
       - run: |
           if [[ `git status --porcelain` ]]; then
             if ${{github.event_name == 'workflow_dispatch'}}; then
-              MSG="Update CHANGELOG.md (Manual Trigger)"
+              MSG="chore: update CHANGELOG.md (Manual Trigger)"
             else
-              MSG="Update CHANGELOG.md for #${{ github.event.pull_request.number }}"
+              MSG="chore: update CHANGELOG.md for #${{ github.event.pull_request.number }}"
             fi
             git config --local user.email changelogbot@frangipane.io
             git config --local user.name changelogbot

--- a/.github/workflows/generate_changelog.yml
+++ b/.github/workflows/generate_changelog.yml
@@ -8,8 +8,9 @@ jobs:
     if: github.event.pull_request.merged || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+      - uses: actions/checkout@v3
         with:
+          token: ${{ secrets.CHANGELOG_PAT }}
           fetch-depth: 0
       - uses: actions/setup-go@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.2.0 (Unreleased)
 
+FEATURES:
+* **New Data Source:** cloudavenue_alb_pool ([GH-246](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/246))
+* **New Data Source:** cloudavenue_network_isolated ([GH-248](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/248))
+* **New Resource:** cloudavenue_alb_pool ([GH-246](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/246))
+
 ## 0.1.1 (April 3, 2023)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-## 0.1.1
+## 0.2.0 (Unreleased)
+
+## 0.1.1 (April 3, 2023)
 
 IMPROVEMENTS:
 
 * Docs: Fix categories
 
-## 0.1.0
+## 0.1.0 (April 3, 2023)
 
 Initial release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,16 +12,17 @@ To contribute code, please follow this steps:
 4. Update the documentation if needed and examples too
 5. Ensure to run `make generate` without issues
 6. Open a pull request
+7. If needed, make a changelog of your changes
 
 Ensure to use a good commit hygiene and follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
 
 ##  Contributing documentation
 
-Documentation is generated from the code using [tfplugindocs](https://github.com/hashicorp/terraform-plugin-docs), you don't need to update the documentation manually in the `docs` folder.
+Documentation is generated from the code using [tfplugindocs](https://github.com/hashicorp/terraform-plugin-docs), you don't need to update the documentation manually in the `docs/` folder.
 
-If you must make manual changes to the documentation, please ensure to edit template in `templates` folder and run `make generate` to update the documentation.
+If you must make manual changes to the documentation, please ensure to edit template in `templates/` folder and run `make generate` to update the documentation.
 
-To add examples or import command in documentation, please add them in the `examples` folder.
+To add examples or import command in documentation, please add them in the `examples/` folder.
 
 ##  Development environment
 
@@ -55,5 +56,90 @@ Run acceptance tests:
 export CLOUDAVENUE_ORG=your-org
 export CLOUDAVENUE_USER=your-user
 export CLOUDAVENUE_PASSWORD=your-password
-make testacc
+export CLOUDAVENUE_VDC=your-vdc
+TF_ACC=1 go test -v -count=1 ./internal/tests/your_test_folder
 ```
+
+##  Changelog format
+
+We use the go-changelog to generate and update the changelog from files created in the .changelog/ directory. It is important that when you raise your Pull Request, there is a changelog entry which describes the changes your contribution makes. Not all changes require an entry in the changelog, guidance follows on what changes do.
+
+The changelog format requires an entry in the following format, where HEADER corresponds to the changelog category, and the entry is the changelog entry itself. The entry should be included in a file in the .changelog directory with the naming convention {PR-NUMBER}.txt. For example, to create a changelog entry for pull request 1234, there should be a file named .changelog/1234.txt.
+
+``````markdown
+```release-note:{HEADER}
+{ENTRY}
+```
+``````
+
+## Pull request types to CHANGELOG
+
+The CHANGELOG is intended to show operator-impacting changes to the codebase for a particular version. If every change or commit to the code resulted in an entry, the CHANGELOG would become less useful for operators. The lists below are general guidelines and examples for when a decision needs to be made to decide whether a change should have an entry.
+
+### Changes that should have a CHANGELOG entry
+
+#### New resource
+
+A new resource entry should only contain the name of the resource, and use the `release-note:new-resource` header.
+
+``````markdown
+```release-note:new-resource
+cloudavenue_alb_pool
+```
+``````
+
+#### New data source
+
+A new data source entry should only contain the name of the data source, and use the `release-note:new-data-source` header.
+
+``````markdown
+```release-note:new-data-source
+cloudavenue_alb_pool
+```
+``````
+
+#### Resource and provider bug fixes
+
+A new bug entry should use the `release-note:bug` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider level fixes.
+
+``````markdown
+```release-note:bug
+resource/cloudavenue_alb_pool: Fix argument being optional
+```
+``````
+
+#### Resource and provider enhancements
+
+A new enhancement entry should use the `release-note:enhancement` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider level enhancements.
+
+``````markdown
+```release-note:enhancement
+resource/cloudavenue_alb_pool: Add new argument
+```
+``````
+
+#### Deprecations
+
+A deprecation entry should use the `release-note:note` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider level changes.
+
+``````markdown
+```release-note:note
+resource/cloudavenue_alb_pool: The old_attribute is being deprecated in favor of the new_attribute to support new feature
+```
+``````
+
+#### Breaking changes and removals
+
+A breaking-change entry should use the `release-note:breaking-change` header and have a prefix indicating the resource or data source it corresponds to, a colon, then followed by a brief summary. Use a `provider` prefix for provider level changes.
+
+``````markdown
+```release-note:breaking-change
+resource/cloudavenue_alb_pool: This is a breaking change
+```
+``````
+
+### Changes that should _not_ have a CHANGELOG entry
+
+- Resource and provider documentation updates
+- Testing updates
+- Code refactoring


### PR DESCRIPTION
Fix CHANGELOG generation by using a PAT to push on main branch

Add the unreleased version in CHANGELOG.md

Rewrite the release-note template