### PR TITLE
ci: fix goreleaser to generate changelog in release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,4 +57,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  skip: false


### PR DESCRIPTION
Try to fix the generation of release note in GitHub Release.

According to the [documentation](https://goreleaser.com/customization/changelog/), it seems that in recent goreleaser version, the changelog Skip: True provide an empty release not in GitHub Release.