### PR TITLE
chore: add acceptance test for `cloudavenue_vm_affinity_rule`resource

### DIFF
--- a/internal/tests/vm/vm_affinity_rule_resource_test.go
+++ b/internal/tests/vm/vm_affinity_rule_resource_test.go
@@ -12,13 +12,59 @@ import (
 //go:generate tf-doc-extractor -filename $GOFILE -example-dir ../../../examples -test
 const testAccVMAffinityRuleResourceConfig = `
 resource "cloudavenue_vm_affinity_rule" "example" {
-  name     = "test"
+  name     = "example-affinity-rule"
   polarity = "Affinity"
 
   vm_ids = [
-    "urn:vcloud:vm:70b78935-cb64-4418-9607-4e3aeabbd168",
-    "urn:vcloud:vm:c3912ae5-bbd1-45ae-8b1e-694d0a405a95"
+    cloudavenue_vm.example.id,
+	cloudavenue_vm.example2.id,
   ]
+}
+
+resource "cloudavenue_vm" "example" {
+	name      = "example-vm"
+	vapp_name = cloudavenue_vapp.example.name
+	deploy_os = {
+	  vapp_template_id = data.cloudavenue_catalog_vapp_template.example.id
+	}
+	settings = {
+	  customization = {
+		auto_generate_password = true
+	  }
+	}
+	resource = {
+	}
+  
+	state = {
+	}
+}
+
+resource "cloudavenue_vm" "example2" {
+	name      = "example-vm2"
+	vapp_name = cloudavenue_vapp.example.name
+	deploy_os = {
+	  vapp_template_id = data.cloudavenue_catalog_vapp_template.example.id
+	}
+	settings = {
+	  customization = {
+		auto_generate_password = true
+	  }
+	}
+	resource = {
+	}
+  
+	state = {
+	}
+}
+
+data "cloudavenue_catalog_vapp_template" "example" {
+	catalog_name = "Orange-Linux"
+	template_name    = "debian_10_X64"
+}
+
+resource "cloudavenue_vapp" "example" {
+	name = "vapp_example"
+	description = "This is a example vapp"
 }
 `
 
@@ -34,26 +80,26 @@ func TestAccVmAffinityRuleResource(t *testing.T) {
 				Config: testAccVMAffinityRuleResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "name", "example-affinity-rule"),
 					resource.TestCheckResourceAttr(resourceName, "polarity", "Affinity"),
 					resource.TestCheckResourceAttr(resourceName, "required", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "vm_ids.0", "urn:vcloud:vm:70b78935-cb64-4418-9607-4e3aeabbd168"),
-					resource.TestCheckResourceAttr(resourceName, "vm_ids.1", "urn:vcloud:vm:c3912ae5-bbd1-45ae-8b1e-694d0a405a95"),
+					resource.TestCheckResourceAttrSet(resourceName, "vm_ids.0"),
+					resource.TestCheckResourceAttrSet(resourceName, "vm_ids.1"),
 				),
 			},
 			// Uncomment if you want to test update or delete this block
 			{
 				// Update test
-				Config: strings.Replace(testAccVMAffinityRuleResourceConfig, "test", "test2", 1),
+				Config: strings.Replace(testAccVMAffinityRuleResourceConfig, "example-affinity-rule", "example-affinity-rule-new", 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "name", "test2"),
+					resource.TestCheckResourceAttr(resourceName, "name", "example-affinity-rule-new"),
 					resource.TestCheckResourceAttr(resourceName, "polarity", "Affinity"),
 					resource.TestCheckResourceAttr(resourceName, "required", "true"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "vm_ids.0", "urn:vcloud:vm:70b78935-cb64-4418-9607-4e3aeabbd168"),
-					resource.TestCheckResourceAttr(resourceName, "vm_ids.1", "urn:vcloud:vm:c3912ae5-bbd1-45ae-8b1e-694d0a405a95"),
+					resource.TestCheckResourceAttrSet(resourceName, "vm_ids.0"),
+					resource.TestCheckResourceAttrSet(resourceName, "vm_ids.1"),
 				),
 			},
 			// ImportruetState testing


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify acceptance tests

### How has this code been tested

```
TF_ACC=1 go test -v -count=1  -run TestAccVmAffinityRuleResource  ./internal/tests/vm
=== RUN   TestAccVmAffinityRuleResource
--- PASS: TestAccVmAffinityRuleResource (394.89s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/vm  395.397s
```