### PR TITLE
fix: Change resource `cloudavenue_network_app_port_profile` to `cloudavenue_edgegateway_app_port_profile` 

### DIFF
--- a/.changelog/347.txt
+++ b/.changelog/347.txt
@@ -1,0 +1,3 @@
+```release-note:chore
+`resource/cloudavenue_edgegateway_app_port_profile` is a resource moved from `cloudavenue_network_app_port_profile`.
+```

--- a/docs/resources/edgegateway_app_port_profile.md
+++ b/docs/resources/edgegateway_app_port_profile.md
@@ -1,11 +1,11 @@
 ---
-page_title: "cloudavenue_network_app_port_profile Resource - cloudavenue"
-subcategory: "Network"
+page_title: "cloudavenue_edgegateway_app_port_profile Resource - cloudavenue"
+subcategory: "Edge Gateway (Tier-1)"
 description: |-
   Provides a NSX-T App Port Profile resource
 ---
 
-# cloudavenue_network_app_port_profile (Resource)
+# cloudavenue_edgegateway_app_port_profile (Resource)
 
 Provides a NSX-T App Port Profile resource
 
@@ -16,7 +16,7 @@ data "cloudavenue_vdc" "example" {
   name = "VDC_Test"
 }
 
-resource "cloudavenue_network_app_port_profile" "example" {
+resource "cloudavenue_edgegateway_app_port_profile" "example" {
   name        = "example-rule"
   description = "Application port profile for example"
   vdc         = data.cloudavenue_vdc.example.id
@@ -68,5 +68,5 @@ Optional:
 
 Import is supported using the following syntax:
 ```shell
-terraform import cloudavenue.network_app_port_profile vdc-or-vdc-group-id.RuleName
+terraform import cloudavenue.edgegateway_app_port_profile vdc-or-vdc-group-id.RuleName
 ```

--- a/examples/resources/cloudavenue_edgegateway_app_port_profile/import.sh
+++ b/examples/resources/cloudavenue_edgegateway_app_port_profile/import.sh
@@ -1,0 +1,1 @@
+terraform import cloudavenue.edgegateway_app_port_profile vdc-or-vdc-group-id.RuleName

--- a/examples/resources/cloudavenue_edgegateway_app_port_profile/resource.tf
+++ b/examples/resources/cloudavenue_edgegateway_app_port_profile/resource.tf
@@ -2,7 +2,7 @@ data "cloudavenue_vdc" "example" {
   name = "VDC_Test"
 }
 
-resource "cloudavenue_network_app_port_profile" "example" {
+resource "cloudavenue_edgegateway_app_port_profile" "example" {
   name        = "example-rule"
   description = "Application port profile for example"
   vdc         = data.cloudavenue_vdc.example.id

--- a/examples/resources/cloudavenue_network_app_port_profile/import.sh
+++ b/examples/resources/cloudavenue_network_app_port_profile/import.sh
@@ -1,1 +1,0 @@
-terraform import cloudavenue.network_app_port_profile vdc-or-vdc-group-id.RuleName

--- a/internal/provider/edgegw/app_port_profile_resource.go
+++ b/internal/provider/edgegw/app_port_profile_resource.go
@@ -1,5 +1,5 @@
 // Package network provides a Terraform resource.
-package network
+package edgegw
 
 import (
 	"context"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -119,6 +119,7 @@ func (p *cloudavenueProvider) Resources(_ context.Context) []func() resource.Res
 		// EDGE GATEWAY
 		edgegw.NewEdgeGatewayResource,
 		edgegw.NewFirewallResource,
+		edgegw.NewPortProfilesResource,
 
 		// VDC
 		vdc.NewVDCResource,
@@ -153,7 +154,6 @@ func (p *cloudavenueProvider) Resources(_ context.Context) []func() resource.Res
 		// NETWORK
 		network.NewNetworkRoutedResource,
 		network.NewNetworkIsolatedResource,
-		network.NewPortProfilesResource,
 	}
 }
 

--- a/internal/tests/edgegw/app_port_profile_resource_test.go
+++ b/internal/tests/edgegw/app_port_profile_resource_test.go
@@ -1,4 +1,4 @@
-package network
+package edgegw
 
 import (
 	"fmt"
@@ -16,7 +16,7 @@ data "cloudavenue_vdc" "example" {
 	name = "VDC_Test"
 }
 
-resource "cloudavenue_network_app_port_profile" "example" {
+resource "cloudavenue_edgegateway_app_port_profile" "example" {
 	name        = "example-rule"
 	description = "Application port profile for example"
 	vdc  		= data.cloudavenue_vdc.example.id
@@ -42,7 +42,7 @@ data "cloudavenue_vdc" "example" {
 	name = "VDC_Test"
 }
 
-resource "cloudavenue_network_app_port_profile" "example" {
+resource "cloudavenue_edgegateway_app_port_profile" "example" {
 	name        = "example-rule"
 	description = "Application port profile for example"
 	vdc  		= data.cloudavenue_vdc.example.id
@@ -71,7 +71,7 @@ resource "cloudavenue_network_app_port_profile" "example" {
 `
 
 func TestAccPortProfilesResource(t *testing.T) {
-	resourceName := "cloudavenue_network_app_port_profile.example"
+	resourceName := "cloudavenue_edgegateway_app_port_profile.example"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { tests.TestAccPreCheck(t) },

--- a/templates/resources/edgegateway_app_port_profile.md.tmpl
+++ b/templates/resources/edgegateway_app_port_profile.md.tmpl
@@ -1,6 +1,6 @@
 ---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
-subcategory: "Network"
+subcategory: "Edge Gateway (Tier-1)"
 description: |-
 {{ .Description | plainmarkdown | trimspace | prefixlines "  " }}
 ---


### PR DESCRIPTION


### Description of your changes

<!--
Change category
-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
TF_ACC=1 go test -v ./internal/tests/edgegw/ -run TestAccPortProfilesResource
=== RUN   TestAccPortProfilesResource
--- PASS: TestAccPortProfilesResource (52.93s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/edgegw      53.262s
```