### PR TITLE
fix: `resource/cloudavenue_vm_affinity_rule` - Set more than 2VMs IDs

### DIFF
--- a/.changelog/380.txt
+++ b/.changelog/380.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+`resource/cloudavenue_vm_affinity_rule` - Fix bug in `vm_ids` attribute. Now it is possible to set more than 2 VMs IDs.
+```
+```release-note:enhancement
+`resource/cloudavenue_vm_affinity_rule` - Add notice in documentation about polarity attribute.
+```

--- a/docs/data-sources/vm_affinity_rule.md
+++ b/docs/data-sources/vm_affinity_rule.md
@@ -87,6 +87,6 @@ resource "cloudavenue_vapp" "example" {
 - `enabled` (Boolean) `True` if this affinity rule is enabled.
 - `polarity` (String) The polarity of the affinity rule.
 - `required` (Boolean) `True` if this affinity rule is required. When a rule is mandatory, a host failover will not power on the VM if doing so would violate the rule.
-- `vm_ids` (List of String) List of VM IDs associated to the affinity rule.
+- `vm_ids` (Set of String) List of VM IDs associated to the affinity rule.
 
 

--- a/docs/resources/vm_affinity_rule.md
+++ b/docs/resources/vm_affinity_rule.md
@@ -9,6 +9,8 @@ description: |-
 
 Provides a Cloud Avenue VM Affinity Rule. This can be used to create, modify and delete VM affinity and anti-affinity rules.
 
+~> **NOTE:** The CloudAvenue UI defines two different entities (`Affinity Rules` and `Anti-Affinity Rules`). This resource combines both entities: they are differentiated by the `polarity` property (see below).
+
 ## Example Usage
 
 ```terraform
@@ -76,7 +78,7 @@ resource "cloudavenue_vapp" "example" {
 
 - `name` (String) VM affinity rule name.
 - `polarity` (String) (ForceNew) The polarity of the affinity rule. Value must be one of : `Affinity`, `Anti-Affinity`.
-- `vm_ids` (List of String) List of VM IDs to apply the affinity rule to. List must contain at most 2 elements. Element value must satisfy all validations: must be a valid URN.
+- `vm_ids` (Set of String) List of VM IDs to apply the affinity rule to. Set must contain at least 2 elements. Element value must satisfy all validations: must be a valid URN.
 
 ### Optional
 

--- a/internal/provider/vm/vm_affinity_rule_datasource.go
+++ b/internal/provider/vm/vm_affinity_rule_datasource.go
@@ -94,7 +94,7 @@ func (d *vmAffinityRuleDataSource) Read(ctx context.Context, req datasource.Read
 	}
 
 	endpointVMs := vmReferencesToListValue(vmAffinityRule.VmAffinityRule.VmReferences)
-	data.VMIDs = types.ListValueMust(types.StringType, endpointVMs)
+	data.VMIDs = types.SetValueMust(types.StringType, endpointVMs)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/vm/vm_affinity_rule_resource.go
+++ b/internal/provider/vm/vm_affinity_rule_resource.go
@@ -157,7 +157,7 @@ func (r *vmAffinityRuleResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	endpointVMs := vmReferencesToListValue(vmAffinityRule.VmAffinityRule.VmReferences)
-	plan.VMIDs = types.ListValueMust(types.StringType, endpointVMs)
+	plan.VMIDs = types.SetValueMust(types.StringType, endpointVMs)
 
 	// Set refreshed state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -215,7 +215,7 @@ func (r *vmAffinityRuleResource) Update(ctx context.Context, req resource.Update
 	}
 
 	endpointVMs := vmReferencesToListValue(vmAffinityRule.VmAffinityRule.VmReferences)
-	plan.VMIDs = types.ListValueMust(types.StringType, endpointVMs)
+	plan.VMIDs = types.SetValueMust(types.StringType, endpointVMs)
 
 	// Set state to fully populated data
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -327,7 +327,7 @@ func (r *vmAffinityRuleResource) ImportState(ctx context.Context, req resource.I
 	}
 
 	endpointVMs := vmReferencesToListValue(vmAffinityRule.VmReferences)
-	state.VMIDs = types.ListValueMust(types.StringType, endpointVMs)
+	state.VMIDs = types.SetValueMust(types.StringType, endpointVMs)
 
 	// Set state to fully populated data
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/provider/vm/vm_affinity_rule_schema.go
+++ b/internal/provider/vm/vm_affinity_rule_schema.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 
 	superschema "github.com/FrangipaneTeam/terraform-plugin-framework-superschema"
@@ -30,7 +30,7 @@ type vmAffinityRuleResourceModel struct {
 	Polarity types.String `tfsdk:"polarity"`
 	Required types.Bool   `tfsdk:"required"`
 	Enabled  types.Bool   `tfsdk:"enabled"`
-	VMIDs    types.List   `tfsdk:"vm_ids"`
+	VMIDs    types.Set    `tfsdk:"vm_ids"`
 }
 
 type vmAffinityRuleDataSourceModel struct {
@@ -40,7 +40,7 @@ type vmAffinityRuleDataSourceModel struct {
 	Polarity types.String `tfsdk:"polarity"`
 	Required types.Bool   `tfsdk:"required"`
 	Enabled  types.Bool   `tfsdk:"enabled"`
-	VMIDs    types.List   `tfsdk:"vm_ids"`
+	VMIDs    types.Set    `tfsdk:"vm_ids"`
 }
 
 /*
@@ -136,20 +136,20 @@ func vmAffinityRuleSchema() superschema.Schema {
 					Computed: true,
 				},
 			},
-			"vm_ids": superschema.ListAttribute{
-				Common: &schemaR.ListAttribute{
+			"vm_ids": superschema.SetAttribute{
+				Common: &schemaR.SetAttribute{
 					MarkdownDescription: "List of VM IDs",
 					ElementType:         types.StringType,
 				},
-				Resource: &schemaR.ListAttribute{
+				Resource: &schemaR.SetAttribute{
 					MarkdownDescription: "to apply the affinity rule to.",
 					Required:            true,
-					Validators: []validator.List{
-						listvalidator.SizeAtMost(2),
-						listvalidator.ValueStringsAre(fstringvalidator.IsURN()),
+					Validators: []validator.Set{
+						setvalidator.SizeAtLeast(2),
+						setvalidator.ValueStringsAre(fstringvalidator.IsURN()),
 					},
 				},
-				DataSource: &schemaD.ListAttribute{
+				DataSource: &schemaD.SetAttribute{
 					MarkdownDescription: "associated to the affinity rule.",
 					Computed:            true,
 				},

--- a/internal/tests/vm/vm_affinity_rule_resource_test.go
+++ b/internal/tests/vm/vm_affinity_rule_resource_test.go
@@ -17,6 +17,7 @@ resource "cloudavenue_vm_affinity_rule" "example" {
   vm_ids = [
     cloudavenue_vm.example.id,
 	cloudavenue_vm.example2.id,
+	cloudavenue_vm.example3.id,
   ]
 }
 
@@ -40,6 +41,24 @@ resource "cloudavenue_vm" "example" {
 
 resource "cloudavenue_vm" "example2" {
 	name      = "example-vm2"
+	vapp_name = cloudavenue_vapp.example.name
+	deploy_os = {
+	  vapp_template_id = data.cloudavenue_catalog_vapp_template.example.id
+	}
+	settings = {
+	  customization = {
+		auto_generate_password = true
+	  }
+	}
+	resource = {
+	}
+  
+	state = {
+	}
+}
+
+resource "cloudavenue_vm" "example3" {
+	name      = "example-vm3"
 	vapp_name = cloudavenue_vapp.example.name
 	deploy_os = {
 	  vapp_template_id = data.cloudavenue_catalog_vapp_template.example.id
@@ -85,6 +104,7 @@ func TestAccVmAffinityRuleResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "vm_ids.0"),
 					resource.TestCheckResourceAttrSet(resourceName, "vm_ids.1"),
+					resource.TestCheckResourceAttrSet(resourceName, "vm_ids.2"),
 				),
 			},
 			// Uncomment if you want to test update or delete this block

--- a/templates/resources/vm_affinity_rule.md.tmpl
+++ b/templates/resources/vm_affinity_rule.md.tmpl
@@ -9,6 +9,8 @@ description: |-
 
 {{ .Description | trimspace }}
 
+~> **NOTE:** The CloudAvenue UI defines two different entities (`Affinity Rules` and `Anti-Affinity Rules`). This resource combines both entities: they are differentiated by the `polarity` property (see below).
+
 {{ if .HasExample -}}
 ## Example Usage
 


### PR DESCRIPTION
### Description of your changes

Fixes #380 

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
TF_ACC=1 go test -v -count=1 -timeout 600m github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/vm/vm_affinity_rule_resource_test.go
=== RUN   TestAccVmAffinityRuleResource
--- PASS: TestAccVmAffinityRuleResource (452.24s)
PASS
ok      command-line-arguments  452.903s
```
