### PR TITLE
fix: bug new cloudavenue publicip return wrong public ip

### DIFF
--- a/internal/tests/publicip/publicip_resource_test.go
+++ b/internal/tests/publicip/publicip_resource_test.go
@@ -9,7 +9,7 @@ import (
 	tests "github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/common"
 )
 
-const testAccVMResourceConfigFromVappTemplate = `
+const testAccPublicIPResource = `
 data "cloudavenue_edgegateways" "example" {}
 
 resource "cloudavenue_publicip" "example" {
@@ -27,7 +27,7 @@ func TestAccPublicIPResource(t *testing.T) {
 			// Read testing
 			{
 				// Apply test
-				Config: testAccVMResourceConfigFromVappTemplate,
+				Config: testAccPublicIPResource,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes

<!--
- "Fix #386": return now good public ip
- "chore": change test name

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
TF_ACC=1 go test -v -count=1 -timeout 600m /Users/micheneaudavid/go/src/github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/publicip/publicip_resource_test.go
=== RUN   TestAccPublicIPResource
--- PASS: TestAccPublicIPResource (112.97s)
PASS
ok      command-line-arguments  113.283s
```