### PR TITLE
fix: `cloudavenue_vapp_*` units tests and improve example

### DIFF
--- a/.changelog/407.txt
+++ b/.changelog/407.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/cloudavenue_iam_user` - Improve examples in documentation.
+```

--- a/.changelog/407.txt
+++ b/.changelog/407.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-`resource/cloudavenue_iam_user` - Improve examples in documentation.
+`resource/cloudavenue_vapp_acl` - Now the attribute `access_level` support `ReadOnly`, `Change` and `FullControl` options. The documentation has been updated accordingly.
 ```

--- a/docs/resources/iam_user.md
+++ b/docs/resources/iam_user.md
@@ -13,7 +13,7 @@ The user resource allows you to manage local users in Cloud Avenue.
 
 ```terraform
 resource "cloudavenue_iam_user" "example" {
-  name              = "exampleuserfull"
+  name              = "example"
   role_name         = "Organization Administrator"
   password          = "Th!s1sSecur3P@ssword"
   enabled           = true # Default true

--- a/docs/resources/vapp.md
+++ b/docs/resources/vapp.md
@@ -15,11 +15,10 @@ Provides a Cloud Avenue vApp resource. This can be used to create, modify, and d
 resource "cloudavenue_vapp" "example" {
   name        = "MyVapp"
   description = "This is an example vApp"
-  power_on    = true
 
   lease = {
     runtime_lease_in_sec = 3600
-    storage_lease_in_sec = 7200
+    storage_lease_in_sec = 3600
   }
 
   guest_properties = {

--- a/docs/resources/vapp_acl.md
+++ b/docs/resources/vapp_acl.md
@@ -13,16 +13,9 @@ Provides a Cloud Avenue Access Control structure for a vApp. This can be used to
 
 ```terraform
 resource "cloudavenue_iam_user" "example" {
-  user_name   = "exampleuser"
-  description = "An example user"
-  role        = "Organization Administrator"
-  password    = "Th!s1sSecur3P@ssword"
-}
-
-resource "cloudavenue_iam_group" "example" {
-  name        = "examplegroup"
-  role        = "Organization Administrator"
-  description = "An example group"
+  name      = "example"
+  role_name = "Organization Administrator"
+  password  = "Th!s1sSecur3P@ssword"
 }
 
 resource "cloudavenue_vapp" "example" {
@@ -31,15 +24,10 @@ resource "cloudavenue_vapp" "example" {
 }
 
 resource "cloudavenue_vapp_acl" "example" {
-  vdc       = "MyVDC" # Optional
   vapp_name = cloudavenue_vapp.example.name
   shared_with = [{
     access_level = "ReadOnly"
     user_id      = cloudavenue_iam_user.example.id
-    },
-    {
-      access_level = "FullControl"
-      group_id     = cloudavenue_iam_group.example.id
   }]
 }
 ```
@@ -64,7 +52,7 @@ resource "cloudavenue_vapp_acl" "example" {
 
 Required:
 
-- `access_level` (String) Access level for the user or group with whom we are sharing. Value must be one of : `ReadOnly`.
+- `access_level` (String) Access level for the user or group with whom we are sharing. Value must be one of : `ReadOnly`, `Change`, `FullControl`.
 
 Optional:
 

--- a/docs/resources/vapp_org_network.md
+++ b/docs/resources/vapp_org_network.md
@@ -49,11 +49,13 @@ resource "cloudavenue_network_routed" "example" {
 resource "cloudavenue_vapp" "example" {
   name        = "MyVapp"
   description = "This is an example vApp"
+  vdc         = "MyVDC"
 }
 
 resource "cloudavenue_vapp_org_network" "example" {
   vapp_name    = cloudavenue_vapp.example.name
   network_name = cloudavenue_network_routed.example.name
+  vdc          = "MyVDC"
 }
 ```
 

--- a/examples/resources/cloudavenue_iam_user/resource.tf
+++ b/examples/resources/cloudavenue_iam_user/resource.tf
@@ -1,5 +1,5 @@
 resource "cloudavenue_iam_user" "example" {
-  name              = "exampleuserfull"
+  name              = "example"
   role_name         = "Organization Administrator"
   password          = "Th!s1sSecur3P@ssword"
   enabled           = true # Default true

--- a/examples/resources/cloudavenue_vapp/resource.tf
+++ b/examples/resources/cloudavenue_vapp/resource.tf
@@ -1,11 +1,10 @@
 resource "cloudavenue_vapp" "example" {
   name        = "MyVapp"
   description = "This is an example vApp"
-  power_on    = true
 
   lease = {
     runtime_lease_in_sec = 3600
-    storage_lease_in_sec = 7200
+    storage_lease_in_sec = 3600
   }
 
   guest_properties = {

--- a/examples/resources/cloudavenue_vapp_acl/resource.tf
+++ b/examples/resources/cloudavenue_vapp_acl/resource.tf
@@ -1,14 +1,7 @@
 resource "cloudavenue_iam_user" "example" {
-  user_name   = "exampleuser"
-  description = "An example user"
-  role        = "Organization Administrator"
-  password    = "Th!s1sSecur3P@ssword"
-}
-
-resource "cloudavenue_iam_group" "example" {
-  name        = "examplegroup"
-  role        = "Organization Administrator"
-  description = "An example group"
+  name      = "example"
+  role_name = "Organization Administrator"
+  password  = "Th!s1sSecur3P@ssword"
 }
 
 resource "cloudavenue_vapp" "example" {
@@ -17,14 +10,9 @@ resource "cloudavenue_vapp" "example" {
 }
 
 resource "cloudavenue_vapp_acl" "example" {
-  vdc       = "MyVDC" # Optional
   vapp_name = cloudavenue_vapp.example.name
   shared_with = [{
     access_level = "ReadOnly"
     user_id      = cloudavenue_iam_user.example.id
-    },
-    {
-      access_level = "FullControl"
-      group_id     = cloudavenue_iam_group.example.id
   }]
 }

--- a/examples/resources/cloudavenue_vapp_org_network/resource.tf
+++ b/examples/resources/cloudavenue_vapp_org_network/resource.tf
@@ -31,9 +31,11 @@ resource "cloudavenue_network_routed" "example" {
 resource "cloudavenue_vapp" "example" {
   name        = "MyVapp"
   description = "This is an example vApp"
+  vdc         = "MyVDC"
 }
 
 resource "cloudavenue_vapp_org_network" "example" {
   vapp_name    = cloudavenue_vapp.example.name
   network_name = cloudavenue_network_routed.example.name
+  vdc          = "MyVDC"
 }

--- a/internal/provider/vapp/acl_resource.go
+++ b/internal/provider/vapp/acl_resource.go
@@ -245,13 +245,13 @@ func (r *aclResource) ImportState(ctx context.Context, req resource.ImportStateR
 	if len(idParts) != 1 && len(idParts) != 2 {
 		resp.Diagnostics.AddError(
 			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: vdc.vapp_name vapp_name. Got: %q", req.ID),
+			fmt.Sprintf("Expected import identifier with format: vdc.vapp_name or vapp_name. Got: %q", req.ID),
 		)
 		return
 	}
 
 	if len(idParts) == 1 {
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("vapp_name"), idParts[0])...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("vapp_name"), req.ID)...)
 	} else {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("vdc"), idParts[0])...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("vapp_name"), idParts[1])...)

--- a/internal/tests/iam/iam_user_datasource_test.go
+++ b/internal/tests/iam/iam_user_datasource_test.go
@@ -10,38 +10,13 @@ import (
 )
 
 const testAccUserDataSourceConfig = `
-resource "cloudavenue_iam_user" "test" {
-	name   = "testuser"
-	role_name   = "Organization Administrator"
-	password    = "Th!s1sSecur3P@ssword"
-}
-
-data "cloudavenue_iam_user" "test" {
-	name = cloudavenue_iam_user.test.name
-}
-`
-
-const testAccUserDataSourceConfigFull = `
-resource "cloudavenue_iam_user" "test" {
-	name              = "testuserfull"
-	role_name         = "Organization Administrator"
-	password          = "Th!s1sSecur3P@ssword"
-	enabled           = true
-	email             = "foo@bar.com"
-	telephone         = "1234567890"
-	full_name         = "Test User"
-	take_ownership    = true
-	deployed_vm_quota = 10
-	stored_vm_quota   = 5
-}
-
-data "cloudavenue_iam_user" "test" {
-	name = cloudavenue_iam_user.test.name
+data "cloudavenue_iam_user" "example" {
+	name = cloudavenue_iam_user.example.name
 }
 `
 
 func TestAccUserDataSource(t *testing.T) {
-	resourceName := "data.cloudavenue_iam_user.test"
+	datasourceName := "data.cloudavenue_iam_user.example"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { tests.TestAccPreCheck(t) },
@@ -49,25 +24,12 @@ func TestAccUserDataSource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Read testing
 			{
-				Config: testAccUserDataSourceConfig,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "testuser"),
-					resource.TestCheckResourceAttr(resourceName, "role_name", "Organization Administrator"),
-					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
-				),
+				Config: tests.ConcatTests(testAccOrgUserResourceConfig, testAccUserDataSourceConfig),
+				Check:  testsOrgUserResourceConfig(datasourceName),
 			},
 			{
-				Config: testAccUserDataSourceConfigFull,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "testuserfull"),
-					resource.TestCheckResourceAttr(resourceName, "role_name", "Organization Administrator"),
-					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "email", "foo@bar.com"),
-					resource.TestCheckResourceAttr(resourceName, "telephone", "1234567890"),
-					resource.TestCheckResourceAttr(resourceName, "full_name", "Test User"),
-					resource.TestCheckResourceAttr(resourceName, "deployed_vm_quota", "10"),
-					resource.TestCheckResourceAttr(resourceName, "stored_vm_quota", "5"),
-				),
+				Config: tests.ConcatTests(testAccOrgUserResourceConfigFull, testAccUserDataSourceConfig),
+				Check:  testsOrgUserResourceConfigFull(datasourceName, true),
 			},
 		},
 	})

--- a/internal/tests/iam/iam_user_resource_test.go
+++ b/internal/tests/iam/iam_user_resource_test.go
@@ -11,16 +11,16 @@ import (
 )
 
 const testAccOrgUserResourceConfig = `
-resource "cloudavenue_iam_user" "test" {
-	name        = "testuser"
+resource "cloudavenue_iam_user" "example" {
+	name        = "example"
 	role_name   = "Organization Administrator"
 	password    = "Th!s1sSecur3P@ssword"
- }
+}
 `
 
 const testAccOrgUserResourceConfigFull = `
-resource "cloudavenue_iam_user" "test" {
-	name              = "testuserfull"
+resource "cloudavenue_iam_user" "example" {
+	name              = "example"
 	role_name         = "Organization Administrator"
 	password          = "Th!s1sSecur3P@ssword"
 	enabled           = true
@@ -33,8 +33,37 @@ resource "cloudavenue_iam_user" "test" {
  }
 `
 
+func testsOrgUserResourceConfig(resourceName string) resource.TestCheckFunc {
+	return resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttr(resourceName, "name", "example"),
+		resource.TestCheckResourceAttr(resourceName, "role_name", "Organization Administrator"),
+		resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+	)
+}
+
+func testsOrgUserResourceConfigFull(resourceName string, isDataSource bool) resource.TestCheckFunc {
+	tests := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "name", "example"),
+		resource.TestCheckResourceAttr(resourceName, "role_name", "Organization Administrator"),
+		resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+		resource.TestCheckResourceAttr(resourceName, "email", "foo@bar.com"),
+		resource.TestCheckResourceAttr(resourceName, "telephone", "1234567890"),
+		resource.TestCheckResourceAttr(resourceName, "full_name", "Test User"),
+		resource.TestCheckResourceAttr(resourceName, "deployed_vm_quota", "10"),
+		resource.TestCheckResourceAttr(resourceName, "stored_vm_quota", "5"),
+	}
+
+	if !isDataSource {
+		tests = append(tests, resource.TestCheckResourceAttr(resourceName, "take_ownership", "true"))
+	}
+
+	return resource.ComposeAggregateTestCheckFunc(
+		tests...,
+	)
+}
+
 func TestAccUserResource(t *testing.T) {
-	resourceName := "cloudavenue_iam_user.test"
+	resourceName := "cloudavenue_iam_user.example"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { tests.TestAccPreCheck(t) },
@@ -43,31 +72,17 @@ func TestAccUserResource(t *testing.T) {
 			// Read testing
 			{
 				Config: testAccOrgUserResourceConfig,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "testuser"),
-					resource.TestCheckResourceAttr(resourceName, "role_name", "Organization Administrator"),
-					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
-				),
+				Check:  testsOrgUserResourceConfig(resourceName),
 			},
 			{
 				Config: testAccOrgUserResourceConfigFull,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "testuserfull"),
-					resource.TestCheckResourceAttr(resourceName, "role_name", "Organization Administrator"),
-					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
-					resource.TestCheckResourceAttr(resourceName, "email", "foo@bar.com"),
-					resource.TestCheckResourceAttr(resourceName, "telephone", "1234567890"),
-					resource.TestCheckResourceAttr(resourceName, "full_name", "Test User"),
-					resource.TestCheckResourceAttr(resourceName, "take_ownership", "true"),
-					resource.TestCheckResourceAttr(resourceName, "deployed_vm_quota", "10"),
-					resource.TestCheckResourceAttr(resourceName, "stored_vm_quota", "5"),
-				),
+				Check:  testsOrgUserResourceConfigFull(resourceName, false),
 			},
 			// ImportState testing
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
-				ImportStateId:     "testuserfull",
+				ImportStateId:     "example",
 				ImportStateVerify: true,
 				// These fields can't be retrieved from user data
 				ImportStateVerifyIgnore: []string{"take_ownership", "password"},

--- a/internal/tests/vapp/acl_resource_test.go
+++ b/internal/tests/vapp/acl_resource_test.go
@@ -1,11 +1,13 @@
 package vapp
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	tests "github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/common"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/pkg/uuid"
@@ -14,59 +16,39 @@ import (
 //go:generate tf-doc-extractor -filename $GOFILE -example-dir ../../../examples -test
 const testAccACLResourceConfig = `
 resource "cloudavenue_iam_user" "example" {
-	user_name   = "exampleuser"
-	description = "An example user"
-	role        = "Organization Administrator"
+	name   		= "example"
+	role_name   = "Organization Administrator"
 	password    = "Th!s1sSecur3P@ssword"
-  }
-
-resource "cloudavenue_iam_group" "example" {
-	name        = "examplegroup"
-	role        = "Organization Administrator"
-	description = "An example group"
-  }
+}
 
 resource "cloudavenue_vapp" "example" {
 	name        = "MyVapp"
 	description = "This is an example vApp"
-  }
+}
 
 resource "cloudavenue_vapp_acl" "example" {
-	vdc                  = "MyVDC" # Optional
-	vapp_name            = cloudavenue_vapp.example.name
+	vapp_name      = cloudavenue_vapp.example.name
 	shared_with = [{
 	  access_level = "ReadOnly"
 	  user_id      = cloudavenue_iam_user.example.id
-	  },
-	  {
-		access_level = "FullControl"
-		group_id     = cloudavenue_iam_group.example.id
-	}]
-  }
+	  }]
+}
 `
 
 const testACLResourceUpdateConfig = `
 resource "cloudavenue_iam_user" "example" {
-	user_name   = "exampleuser"
-	description = "An example user"
-	role        = "Organization Administrator"
+	name   		= "example"
+	role_name   = "Organization Administrator"
 	password    = "Th!s1sSecur3P@ssword"
-  }
-
-resource "cloudavenue_iam_group" "example" {
-	name        = "examplegroup"
-	role        = "Organization Administrator"
-	description = "An example group"
-  }
+}
 
 resource "cloudavenue_vapp" "example" {
 	name        = "MyVapp"
 	description = "This is an example vApp"
-  }
+}
 
 resource "cloudavenue_vapp_acl" "example" {
-	vdc                   = "MyVDC" # Optional
-	vapp_name             = cloudavenue_vapp.example.name
+	vapp_name     		  = cloudavenue_vapp.example.name
 	everyone_access_level = "Change"
   }
 `
@@ -86,7 +68,6 @@ func TestAccACLResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "vdc", os.Getenv("CLOUDAVENUE_VDC")),
 					resource.TestCheckResourceAttr(resourceName, "vapp_name", "MyVapp"),
 					resource.TestCheckResourceAttrSet(resourceName, "shared_with.0.subject_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "shared_with.1.subject_name"),
 				),
 			},
 			// Uncomment if you want to test update or delete this block
@@ -100,13 +81,13 @@ func TestAccACLResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "everyone_access_level", "Change"),
 				),
 			},
-			// ImportruetState testing
+			// // ImportruetState testing
 			{
 				// Import test
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateId:     "MyVDC.MyVapp",
+				ImportStateIdFunc: testAccACLResourceImportStateIDFunc(resourceName),
 			},
 			{
 				// Import test
@@ -117,4 +98,15 @@ func TestAccACLResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccACLResourceImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return fmt.Sprintf("%s.%s", rs.Primary.Attributes["vdc"], rs.Primary.Attributes["vapp_name"]), nil
+	}
 }

--- a/internal/tests/vapp/org_network_resource_test.go
+++ b/internal/tests/vapp/org_network_resource_test.go
@@ -1,7 +1,6 @@
 package vapp
 
 import (
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -44,17 +43,19 @@ resource "cloudavenue_network_routed" "example" {
 resource "cloudavenue_vapp" "example" {
   name        = "MyVapp"
   description = "This is an example vApp"
+  vdc         = "MyVDC"
 }
 
 resource "cloudavenue_vapp_org_network" "example" {
   vapp_name    = cloudavenue_vapp.example.name
   network_name = cloudavenue_network_routed.example.name
+  vdc          = "MyVDC"
 }
 `
 
-const resourceName = "cloudavenue_vapp_org_network.example"
-
 func TestAccOrgNetworkResource(t *testing.T) {
+	resourceName := "cloudavenue_vapp_org_network.example"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { tests.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: tests.TestAccProtoV6ProviderFactories,
@@ -65,20 +66,12 @@ func TestAccOrgNetworkResource(t *testing.T) {
 				Config: testAccOrgNetworkResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "vdc", os.Getenv("CLOUDAVENUE_VDC")),
+					resource.TestCheckResourceAttr(resourceName, "vdc", "MyVDC"),
 					resource.TestCheckResourceAttr(resourceName, "vapp_name", "MyVapp"),
 					resource.TestCheckResourceAttr(resourceName, "network_name", "MyOrgNet"),
 				),
 			},
-			// Uncomment if you want to test update or delete this block
-			// {
-			// 	// Update test
-			// 	Config: strings.Replace(testAccOrgNetworkResourceConfig, "old", "new", 1),
-			// 	Check: resource.ComposeAggregateTestCheckFunc(
-			// 		resource.TestCheckResourceAttrSet(resourceName, "id"),
-			// 	),
-			// },
-			// ImportruetState testing
+			// Import
 			{
 				// Import test without vdc
 				ResourceName:      resourceName,
@@ -86,6 +79,7 @@ func TestAccOrgNetworkResource(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateId:     "MyVapp.MyOrgNet",
 			},
+			// Import
 			{
 				// Import test with vdc
 				ResourceName:      resourceName,

--- a/internal/tests/vapp/org_network_resource_test.go
+++ b/internal/tests/vapp/org_network_resource_test.go
@@ -73,14 +73,6 @@ func TestAccOrgNetworkResource(t *testing.T) {
 			},
 			// Import
 			{
-				// Import test without vdc
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateId:     "MyVapp.MyOrgNet",
-			},
-			// Import
-			{
 				// Import test with vdc
 				ResourceName:      resourceName,
 				ImportState:       true,

--- a/internal/tests/vapp/vapp_resource_test.go
+++ b/internal/tests/vapp/vapp_resource_test.go
@@ -15,11 +15,10 @@ const testAccEVappResourceConfig = `
 resource "cloudavenue_vapp" "example" {
 	name        = "MyVapp"
 	description = "This is an example vApp"
-	power_on = true
 
 	lease = {
 		runtime_lease_in_sec = 3600
-		storage_lease_in_sec = 7200
+		storage_lease_in_sec = 3600
 	}
 
 	guest_properties = {
@@ -32,6 +31,7 @@ const testAccEVappResourceUpdatedConfig = `
 resource "cloudavenue_vapp" "example" {
 	name        = "MyVapp"
 	description = "This is an example modified vApp"
+}
 `
 
 func TestAccVappResource(t *testing.T) {
@@ -49,10 +49,9 @@ func TestAccVappResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", "MyVapp"),
 					resource.TestCheckResourceAttr(resourceName, "vdc", os.Getenv("CLOUDAVENUE_VDC")),
 					resource.TestCheckResourceAttr(resourceName, "description", "This is an example vApp"),
-					resource.TestCheckResourceAttr(resourceName, "power_on", "true"),
 					resource.TestCheckResourceAttr(resourceName, "lease.runtime_lease_in_sec", "3600"),
-					resource.TestCheckResourceAttr(resourceName, "lease.storage_lease_in_sec", "7200"),
-					resource.TestCheckResourceAttrSet(resourceName, "guest_properties.#"),
+					resource.TestCheckResourceAttr(resourceName, "lease.storage_lease_in_sec", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "guest_properties.key", "Value"),
 				),
 			},
 			// Update
@@ -63,7 +62,6 @@ func TestAccVappResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", "MyVapp"),
 					resource.TestCheckResourceAttr(resourceName, "vdc", os.Getenv("CLOUDAVENUE_VDC")),
 					resource.TestCheckResourceAttr(resourceName, "description", "This is an example modified vApp"),
-					resource.TestCheckResourceAttr(resourceName, "power_on", "false"),
 					resource.TestCheckResourceAttr(resourceName, "lease.runtime_lease_in_sec", "0"),
 					resource.TestCheckResourceAttr(resourceName, "lease.storage_lease_in_sec", "0"),
 					resource.TestCheckNoResourceAttr(resourceName, "guest_properties.#"),
@@ -75,7 +73,6 @@ func TestAccVappResource(t *testing.T) {
 				ImportState:       true,
 				ImportStateId:     "MyVapp",
 				ImportStateVerify: true,
-				Destroy:           true,
 			},
 		},
 	})


### PR DESCRIPTION
### Description of your changes

Fix units tests for Vapp Resources. 

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

#### `cloudavenue_iam_user` Resource/DataSource
```
=== RUN   TestAccUserResource
--- PASS: TestAccUserResource (19.82s)
PASS
ok      command-line-arguments  20.394s
```

```
=== RUN   TestAccUserDataSource
--- PASS: TestAccUserDataSource (23.36s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/tests/iam 23.948s
```

#### `cloudavenue_vapp_acl` Resource 
```
=== RUN   TestAccACLResource
--- PASS: TestAccACLResource (43.17s)
PASS
ok      command-line-arguments  43.736s
``` 

#### `cloudavenue_vapp` Resource 
```
=== RUN   TestAccVappResource
--- PASS: TestAccVappResource (50.06s)
PASS
ok      command-line-arguments  50.432s
```

#### `cloudavenue_vapp_org_network` Resource
```
=== RUN   TestAccOrgNetworkResource
--- PASS: TestAccOrgNetworkResource (231.67s)
PASS
ok      command-line-arguments  232.230s
```