### PR TITLE
fix: error VDC group name cannot be update in vcd resource

### DIFF
--- a/.changelog/511.txt
+++ b/.changelog/511.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_vcd` - Fix bug to impossible to update a vcd resource with a resource vcd_group define.
+```

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.18.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/iancoleman/strcase v0.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.28.0
+	github.com/iancoleman/strcase v0.3.0
 	github.com/orange-cloudavenue/cloudavenue-sdk-go v0.1.2
 	github.com/rs/zerolog v1.30.0
 	github.com/vmware/go-vcloud-director/v2 v2.21.0


### PR DESCRIPTION
<!--
"Fixes #511":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
TF_ACC=1 go test -v -count=1 -timeout 30m -run TestAccVDCResource
=== RUN   TestAccVDCResource
```