### PR TITLE
fix: bug to impossible to update a vcd resource without a resource vcd_group define

### DIFF
--- a/.changelog/518.txt
+++ b/.changelog/518.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+`resource/cloudavenue_vcd` - Fix bug to impossible to update a vcd resource without a resource vcd_group define.
+```
+
+```release-note:dependency
+deps: bumps github.com/orange-cloudavenue/cloudavenue-sdk-go from 0.1.2 to 0.1.3
+```

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,8 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.28.0
 	github.com/iancoleman/strcase v0.3.0
-	github.com/orange-cloudavenue/cloudavenue-sdk-go v0.1.2
+	github.com/kr/pretty v0.3.1
+	github.com/orange-cloudavenue/cloudavenue-sdk-go v0.1.3
 	github.com/rs/zerolog v1.30.0
 	github.com/vmware/go-vcloud-director/v2 v2.21.0
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
@@ -57,7 +58,6 @@ require (
 	github.com/hashicorp/yamux v0.1.1 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.18 // indirect

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/orange-cloudavenue/cloudavenue-sdk-go v0.1.2 h1:xyuYnnne38RHQqnFw1d5M9FllvlWN4qNQDKV1AQNGpI=
-github.com/orange-cloudavenue/cloudavenue-sdk-go v0.1.2/go.mod h1:bMSQ+EQ0CtwIca1J133sM9fc/4cAfLXN3r4TpnS0BDY=
+github.com/orange-cloudavenue/cloudavenue-sdk-go v0.1.3 h1:nnFO5vxf70gWZkPcM153LYwHA1fa+0QqtzH2t71AMFA=
+github.com/orange-cloudavenue/cloudavenue-sdk-go v0.1.3/go.mod h1:bMSQ+EQ0CtwIca1J133sM9fc/4cAfLXN3r4TpnS0BDY=
 github.com/peterhellberg/link v1.2.0 h1:UA5pg3Gp/E0F2WdX7GERiNrPQrM1K6CVJUUWfHa4t6c=
 github.com/peterhellberg/link v1.2.0/go.mod h1:gYfAh+oJgQu2SrZHg5hROVRQe1ICoK0/HHJTcE0edxc=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=

--- a/internal/provider/vdc/vdc_resource.go
+++ b/internal/provider/vdc/vdc_resource.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/kr/pretty"
 	"golang.org/x/exp/slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
 	apiclient "github.com/orange-cloudavenue/cloudavenue-sdk-go"
@@ -363,7 +361,6 @@ func (r *vdcResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	if !state.VDCGroup.IsNull() {
 		body.VdcGroup = state.VDCGroup.ValueString()
 	}
-	tflog.Info(ctx, pretty.Sprint(body))
 
 	// Iterate over the storage profiles and add them to the body.
 	for _, storageProfile := range plan.VDCStorageProfiles {


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes

Fix bug to impossible to update a vcd resource without a resource vcd_group define