### PR TITLE
fix: update testacc vdcgroup and vdc resource

### DIFF
--- a/.changelog/521.txt
+++ b/.changelog/521.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_vdc` - Fix bug in vdc about vdcgroup field or vdc_group resource.
+```

--- a/internal/provider/vdc/vdc_resource.go
+++ b/internal/provider/vdc/vdc_resource.go
@@ -346,11 +346,26 @@ func (r *vdcResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		return
 	}
 
-	var err error
+	// Get vDC info
 	var httpR *http.Response
+	var err error
+	var group string
+	vdc, httpR, err := r.client.APIClient.VDCApi.GetOrgVdcByName(auth, state.Name.ValueString())
+	if httpR != nil {
+		defer func() {
+			err = errors.Join(err, httpR.Body.Close())
+		}()
+	}
+	// check if vdcGroup exists
+	if !plan.VDCGroup.IsNull() {
+		group = plan.VDCGroup.ValueString()
+	} else {
+		group = vdc.VdcGroup
+	}
 
 	// Convert from Terraform data model into API data model
 	body := apiclient.UpdateOrgVdcV2{
+		VdcGroup: group,
 		Vdc: &apiclient.OrgVdcV2{
 			Name:                   plan.Name.ValueString(),
 			Description:            plan.Description.ValueString(),

--- a/internal/testsacc/vdc_resource_test.go
+++ b/internal/testsacc/vdc_resource_test.go
@@ -13,7 +13,6 @@ import (
 const testAccVDCResourceConfig = `
 resource "cloudavenue_vdc" "example" {
 	name                  = "MyVDC1"
-	vdc_group             = "MyGroup"
 	description           = "Example vDC created by Terraform"
 	cpu_allocated         = 22000
 	memory_allocated      = 30
@@ -28,8 +27,13 @@ resource "cloudavenue_vdc" "example" {
 	  default = true
 	  limit   = 500
 	}]
-  
-  }
+}
+resource "cloudavenue_vdc_group" "example" {
+	name = "MyGroup"
+	vdc_ids = [
+		cloudavenue_vdc.example.id,
+	]
+}
 `
 
 // Temp test during deprecation notice of vdc_group attribute
@@ -52,7 +56,6 @@ resource "cloudavenue_vdc" "example" {
 	  default = true
 	  limit   = 500
 	}]
-  
 }
 
 resource "cloudavenue_vdc" "example2" {
@@ -87,7 +90,6 @@ func TestAccVDCResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(uuid.VDC.String()+`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)),
 					resource.TestCheckResourceAttr(resourceName, "name", "MyVDC1"),
-					resource.TestCheckResourceAttr(resourceName, "vdc_group", "MyGroup"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Example vDC created by Terraform"),
 					resource.TestCheckResourceAttr(resourceName, "cpu_allocated", "22000"),
 					resource.TestCheckResourceAttr(resourceName, "memory_allocated", "30"),
@@ -108,7 +110,6 @@ func TestAccVDCResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(uuid.VDC.String()+`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)),
 					resource.TestCheckResourceAttr(resourceName, "name", "MyVDC1"),
-					resource.TestCheckResourceAttr(resourceName, "vdc_group", "MyGroup"),
 					resource.TestCheckResourceAttr(resourceName, "description", "Example vDC created by Terraform"),
 					resource.TestCheckResourceAttr(resourceName, "cpu_allocated", "22000"),
 					resource.TestCheckResourceAttr(resourceName, "memory_allocated", "40"),


### PR DESCRIPTION
Fix bug for vdc update in relation ship with field vdcgroup or resource vdc_group
Fix vdc test acc

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested
```TF_ACC=1 go test -v ./internal/testsacc/ -count=1 -timeout 30m -run TestAccVDCResource
=== RUN   TestAccVDCResource
--- PASS: TestAccVDCResource (94.01s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  94.379s
```