### PR TITLE
feat: Change attribute field for import resource by EdgeGatewayName or EdgeGatewayID. (#525)

### DIFF
--- a/.changelog/526.txt
+++ b/.changelog/526.txt
@@ -1,3 +1,3 @@
 ```release-note:breaking-change
-`cloudavenue_network_routed` - Change attribute field for import resource by EdgeGatewayName or EdgeGatewayID.
+`resource/cloudavenue_network_routed` - Change attribute field for import resource by EdgeGatewayName or EdgeGatewayID.
 ```

--- a/.changelog/526.txt
+++ b/.changelog/526.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+`cloudavenue_network_routed` - Change attribute field for import resource by EdgeGatewayName or EdgeGatewayID.
+```

--- a/docs/resources/network_routed.md
+++ b/docs/resources/network_routed.md
@@ -75,5 +75,5 @@ Required:
 
 Import is supported using the following syntax:
 ```shell
-terraform import vdc-or-vdc-group-name.NetworkName
+terraform import edge-gateway-name-or-id.NetworkName
 ```

--- a/docs/resources/network_routed.md
+++ b/docs/resources/network_routed.md
@@ -75,5 +75,5 @@ Required:
 
 Import is supported using the following syntax:
 ```shell
-terraform import edge-gateway-name-or-id.NetworkName
+terraform import EdgeGatewayName.NetworkName Or EdgeGatewayID.NetworkName
 ```

--- a/examples/resources/cloudavenue_network_routed/import.sh
+++ b/examples/resources/cloudavenue_network_routed/import.sh
@@ -1,1 +1,2 @@
-terraform import edge-gateway-name-or-id.NetworkName
+terraform import EdgeGatewayName.NetworkName Or EdgeGatewayID.NetworkName
+

--- a/examples/resources/cloudavenue_network_routed/import.sh
+++ b/examples/resources/cloudavenue_network_routed/import.sh
@@ -1,1 +1,1 @@
-terraform import vdc-or-vdc-group-name.NetworkName
+terraform import edge-gateway-name-or-id.NetworkName

--- a/internal/helpers/testsacc/testsacc.go
+++ b/internal/helpers/testsacc/testsacc.go
@@ -166,10 +166,20 @@ func (t TFData) String() string {
 
 // Append appends the given Terraform configuration to the current one.
 func (t *TFData) Append(tf TFData) {
-	if !listOfDeps.Exists(ResourceName(tf.extractResourceName())) {
+	if !tf.IsEmpty() && !listOfDeps.Exists(ResourceName(tf.extractResourceName())) {
 		t.append(tf)
 		listOfDeps.Append(ResourceName(tf.extractResourceName()))
 	}
+}
+
+// AppendWithoutResourceName appends the given Terraform configuration to the current one.
+func (t *TFData) AppendWithoutResourceName(tf TFData) {
+	t.appendWithoutResourceName(tf)
+}
+
+// is empty.
+func (t *TFData) IsEmpty() bool {
+	return t.String() == ""
 }
 
 // appendWithoutResourceName appends the given Terraform configuration to the current one.

--- a/internal/testsacc/acctest.go
+++ b/internal/testsacc/acctest.go
@@ -84,7 +84,7 @@ func (r resourceConfig) GetSpecificConfig(testName string) testsacc.TFData {
 		context.Background(),
 		r.GetResourceName(),
 	).Create.TFConfig
-	x.Append(r.DependenciesConfig())
+	x.AppendWithoutResourceName(r.DependenciesConfig())
 	return x
 }
 

--- a/internal/testsacc/network_routed_resource_test.go
+++ b/internal/testsacc/network_routed_resource_test.go
@@ -84,18 +84,13 @@ func (r *NetworkRoutedResource) Tests(ctx context.Context) map[testsacc.TestName
 						resource "cloudavenue_network_routed" "example" {
 							name        = {{ get . "name" }}
 							description = {{ get . "description" }}
-						  
-							edge_gateway_id = cloudavenue_edgegateway.example.id
-						  
-							gateway       = "192.168.1.250"
+											edge_gateway_id = cloudavenue_edgegateway.example.id
+											gateway       = "192.168.1.250"
 							prefix_length = 24
-						  
-							dns1 = "1.1.1.2"
+											dns1 = "1.1.1.2"
 							dns2 = "8.8.8.9"
-						  
-							dns_suffix = "exampleupdated"
-						  
-							static_ip_pool = [
+											dns_suffix = "exampleupdated"
+											static_ip_pool = [
 							  {
 								start_address = "192.168.1.1"
 								end_address   = "192.168.1.30"
@@ -115,14 +110,18 @@ func (r *NetworkRoutedResource) Tests(ctx context.Context) map[testsacc.TestName
 					},
 				},
 				// ! Imports testing
-				// TODO : Add import test after resolving this issue https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/526
-				// Imports: []testsacc.TFImport{
-				// 	{
-				// 		ImportStateIDBuilder: []string{"edge_gateway_name", "name"},
-				// 		ImportState:          true,
-				// 		ImportStateVerify:    true,
-				// 	},
-				// },
+				Imports: []testsacc.TFImport{
+					{
+						ImportStateIDBuilder: []string{"edge_gateway_name", "name"},
+						ImportState:          true,
+						ImportStateVerify:    true,
+					},
+					{
+						ImportStateIDBuilder: []string{"edge_gateway_id", "name"},
+						ImportState:          true,
+						ImportStateVerify:    true,
+					},
+				},
 			}
 		},
 	}


### PR DESCRIPTION
<!--
Change import attribute with `cloudavenue_edgegateway` ID or Name, in order to be more coherent.
-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
TF_ACC=1 go test -v ./internal/testsacc/ -count=1 -timeout 30m -run TestAccNetworkRoutedResource
=== RUN   TestAccNetworkRoutedResource
--- PASS: TestAccNetworkRoutedResource (374.86s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  375.171s
```