### PR TITLE
fix!: remove attributs `is_fenced` and `retain_ip_mac_enabled`

### DIFF
--- a/.changelog/538.txt
+++ b/.changelog/538.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+`resource/cloudavenue_vapp_org_network` - `is_fenced` and `retain_ip_mac_enabled` are now removed from the schema.
+```
+
+```release-note:breaking-change
+`datasource/cloudavenue_vapp_org_network` - `is_fenced` and `retain_ip_mac_enabled` are now removed from the schema.
+```

--- a/docs/data-sources/vapp_org_network.md
+++ b/docs/data-sources/vapp_org_network.md
@@ -77,6 +77,4 @@ data "cloudavenue_vapp_org_network" "example" {
 ### Read-Only
 
 - `id` (String) The ID of the network.
-- `is_fenced` (Boolean) Defines if the network is fenced. Fencing allows identical virtual machines in different vApp networks connect to organization VDC networks that are accessed in this vApp.
-- `retain_ip_mac_enabled` (Boolean) Specifies whether the network resources such as IP/MAC of router will be retained across deployments.
 

--- a/docs/resources/vapp_org_network.md
+++ b/docs/resources/vapp_org_network.md
@@ -68,8 +68,6 @@ resource "cloudavenue_vapp_org_network" "example" {
 
 ### Optional
 
-- `is_fenced` (Boolean) Defines if the network is fenced. Fencing allows identical virtual machines in different vApp networks connect to organization VDC networks that are accessed in this vApp. Value defaults to `false`.
-- `retain_ip_mac_enabled` (Boolean) Specifies whether the network resources such as IP/MAC of router will be retained across deployments. Value defaults to `false`.
 - `vapp_id` (String) (ForceNew) ID of the vApp. Ensure that one and only one attribute from this collection is set : `vapp_name`, `vapp_id`.
 - `vapp_name` (String) (ForceNew) Name of the vApp. Ensure that one and only one attribute from this collection is set : `vapp_id`, `vapp_name`.
 - `vdc` (String) (ForceNew) The name of vDC to use, optional if defined at provider level.

--- a/internal/provider/common/network/schema.go
+++ b/internal/provider/common/network/schema.go
@@ -7,7 +7,6 @@ import (
 	schemaD "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	schemaR "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -354,26 +353,6 @@ func GetSchema(opts ...networkSchemaOpts) superschema.Schema {
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
-			},
-		}
-		_schema.Attributes["is_fenced"] = superschema.BoolAttribute{
-			Common: &schemaR.BoolAttribute{
-				MarkdownDescription: "Defines if the network is fenced. Fencing allows identical virtual machines in different vApp networks connect to organization VDC networks that are accessed in this vApp.",
-				Computed:            true,
-			},
-			Resource: &schemaR.BoolAttribute{
-				Optional: true,
-				Default:  booldefault.StaticBool(false),
-			},
-		}
-		_schema.Attributes["retain_ip_mac_enabled"] = superschema.BoolAttribute{
-			Common: &schemaR.BoolAttribute{
-				MarkdownDescription: "Specifies whether the network resources such as IP/MAC of router will be retained across deployments.",
-				Computed:            true,
-			},
-			Resource: &schemaR.BoolAttribute{
-				Optional: true,
-				Default:  booldefault.StaticBool(false),
 			},
 		}
 	}

--- a/internal/provider/vapp/org_network_datasource.go
+++ b/internal/provider/vapp/org_network_datasource.go
@@ -121,24 +121,13 @@ func (d *orgNetworkDataSource) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
-	// Set Attributes
-	var isFenced, retainIPMacEnabled bool
-	if vAppNetwork.Configuration == nil {
-		// Set default value if configuration return is nil
-		vAppNetwork.Configuration = &govcdtypes.NetworkConfiguration{}
-	} else {
-		isFenced = vAppNetwork.Configuration.FenceMode == govcdtypes.FenceModeNAT
-		retainIPMacEnabled = *vAppNetwork.Configuration.RetainNetInfoAcrossDeployments
-	}
 	// Set data
 	plan := &orgNetworkModel{
-		ID:                 types.StringValue(uuid.Normalize(uuid.Network, *networkID).String()),
-		VAppName:           utils.StringValueOrNull(d.vapp.GetName()),
-		VAppID:             utils.StringValueOrNull(d.vapp.GetID()),
-		VDC:                types.StringValue(d.vdc.GetName()),
-		NetworkName:        data.NetworkName,
-		IsFenced:           types.BoolValue(isFenced),
-		RetainIPMacEnabled: types.BoolValue(retainIPMacEnabled),
+		ID:          types.StringValue(uuid.Normalize(uuid.Network, *networkID).String()),
+		VAppName:    utils.StringValueOrNull(d.vapp.GetName()),
+		VAppID:      utils.StringValueOrNull(d.vapp.GetID()),
+		VDC:         types.StringValue(d.vdc.GetName()),
+		NetworkName: data.NetworkName,
 	}
 
 	// Save data into Terraform state

--- a/internal/provider/vapp/vapp_types.go
+++ b/internal/provider/vapp/vapp_types.go
@@ -16,11 +16,9 @@ var vappLeaseAttrTypes = map[string]attr.Type{
 }
 
 type orgNetworkModel struct {
-	ID                 types.String `tfsdk:"id"`
-	VAppName           types.String `tfsdk:"vapp_name"`
-	VAppID             types.String `tfsdk:"vapp_id"`
-	VDC                types.String `tfsdk:"vdc"`
-	NetworkName        types.String `tfsdk:"network_name"`
-	IsFenced           types.Bool   `tfsdk:"is_fenced"`
-	RetainIPMacEnabled types.Bool   `tfsdk:"retain_ip_mac_enabled"`
+	ID          types.String `tfsdk:"id"`
+	VAppName    types.String `tfsdk:"vapp_name"`
+	VAppID      types.String `tfsdk:"vapp_id"`
+	VDC         types.String `tfsdk:"vdc"`
+	NetworkName types.String `tfsdk:"network_name"`
 }

--- a/internal/testsacc/acctest.go
+++ b/internal/testsacc/acctest.go
@@ -3,6 +3,7 @@ package testsacc
 
 import (
 	"context"
+	"log"
 	"os"
 	"testing"
 
@@ -53,6 +54,7 @@ func TestAccPreCheck(t *testing.T) {
 	// Not error checking here because it's not critical.
 	x, _ := uuid.NewUUID()
 	metrics.GlobalExecutionID = "testacc_" + x.String()
+	log.Default().Printf("TestACC: execution ID is %s", metrics.GlobalExecutionID)
 }
 
 // Deprecated: Use ContactConfigs instead.

--- a/internal/testsacc/vapp_org_network_datasource_test.go
+++ b/internal/testsacc/vapp_org_network_datasource_test.go
@@ -74,8 +74,6 @@ func TestAccOrgNetworkDataSource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(uuid.Network.String()+`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)),
 					resource.TestCheckResourceAttrPair(dataSourceName, "network_name", resourceName, "network_name"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "is_fenced", resourceName, "is_fenced"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "retain_ip_mac_enabled", resourceName, "retain_ip_mac_enabled"),
 				),
 			},
 		},

--- a/internal/testsacc/vapp_org_network_resource_test.go
+++ b/internal/testsacc/vapp_org_network_resource_test.go
@@ -40,11 +40,10 @@ func (r *VAppOrgNetworkResource) Tests(ctx context.Context) map[testsacc.TestNam
 			return testsacc.Test{
 				CommonChecks: []resource.TestCheckFunc{
 					resource.TestCheckResourceAttrWith(resourceName, "id", uuid.TestIsType(uuid.Network)),
-					resource.TestCheckResourceAttrSet(resourceName, "vapp_name"),
-					resource.TestCheckResourceAttrSet(resourceName, "network_name"),
 					resource.TestCheckResourceAttrSet(resourceName, "vdc"),
-					// TODO : https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/527
-					// resource.TestCheckResourceAttrSet(resourceName, "vapp_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "vapp_name"),
+					resource.TestCheckNoResourceAttr(resourceName, "vapp_id"),
 				},
 				// ! Create testing
 				Create: testsacc.TFConfig{
@@ -54,28 +53,10 @@ func (r *VAppOrgNetworkResource) Tests(ctx context.Context) map[testsacc.TestNam
 						network_name = cloudavenue_network_routed.example.name
 						vdc          = cloudavenue_vdc.example.name
 					  }`),
-					Checks: []resource.TestCheckFunc{
-						resource.TestCheckResourceAttr(resourceName, "is_fenced", "false"),
-						resource.TestCheckResourceAttr(resourceName, "retain_ip_mac_enabled", "false"),
-					},
+					Checks: []resource.TestCheckFunc{},
 				},
-				// TODO : Impossible to update due to https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/531 and https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/529
-				// // ! Updates testing
-				// Updates: []testsacc.TFConfig{
-				// 	{
-				// 		TFConfig: testsacc.GenerateFromTemplate(resourceName, `
-				// 		resource "cloudavenue_vapp_org_network" "example" {
-				// 			vapp_name    = cloudavenue_vapp.example.name
-				// 			network_name = cloudavenue_network_routed.example.name
-				// 			vdc          = cloudavenue_vdc.example.name
-
-				// 			retain_ip_mac_enabled = true
-				// 		  }`),
-				// 		Checks: []resource.TestCheckFunc{
-				// 			resource.TestCheckResourceAttr(resourceName, "retain_ip_mac_enabled", "true"),
-				// 		},
-				// 	},
-				// },
+				// ! Update testing
+				// * No update for this resource
 				// ! Imports testing
 				Imports: []testsacc.TFImport{
 					{


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
=== RUN   TestAccOrgNetworkResource
--- PASS: TestAccOrgNetworkResource (488.83s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  489.398s
```