### PR TITLE
fix: testAcc Get checks from resource to datasource

### DIFF
--- a/internal/helpers/testsacc/template.go
+++ b/internal/helpers/testsacc/template.go
@@ -20,11 +20,11 @@ var (
 			}
 
 			randomString := generateRandomString(extraOpts[0])
-			(*KeyValueStore)[buildkeyValueStore(resourceName, key)] = randomString
+			(*KeyValueStore)[buildKeyValueStore(resourceName, key)] = randomString
 			return returnWithQuotes(randomString)
 		},
 		"get": func(resourceName, key string) string {
-			if v, ok := (*KeyValueStore)[buildkeyValueStore(resourceName, key)]; ok {
+			if v, ok := (*KeyValueStore)[buildKeyValueStore(resourceName, key)]; ok {
 				if s, ok := v.(string); ok {
 					return returnWithQuotes(s)
 				}
@@ -50,6 +50,9 @@ var (
 //   - generate: generates a random string and stores it in the key-value store. Generate accepts an optional argument that specifies the format of the random string (available formats: "shortString", "longString"). Default format is "shortString".
 //   - get: returns the value of the given key from the key-value store.
 func GenerateFromTemplate(resourceName, templateData string) TFData {
+	// if prefix of resourceName is "data." then remove it
+	resourceName = strings.TrimPrefix(resourceName, "data.")
+
 	t, _ := template.New(resourceName).Funcs(templateFuncs).Parse(templateData)
 	var tplTypes bytes.Buffer
 	_ = t.Execute(&tplTypes, resourceName)
@@ -60,16 +63,20 @@ func GenerateFromTemplate(resourceName, templateData string) TFData {
 
 // GetValueFromTemplate returns the value of the given key from the key-value store.
 func GetValueFromTemplate(resourceName, key string) string {
-	if v, ok := (*KeyValueStore)[buildkeyValueStore(resourceName, key)]; ok {
+	// if prefix of resourceName is "data." then remove it
+	resourceName = strings.TrimPrefix(resourceName, "data.")
+
+	if v, ok := (*KeyValueStore)[buildKeyValueStore(resourceName, key)]; ok {
 		if s, ok := v.(string); ok {
 			return s
 		}
 	}
+
 	return ""
 }
 
-// buildkeyValueStore builds the key-value store.
-func buildkeyValueStore(resourceName, key string) string {
+// buildKeyValueStore builds the key-value store.
+func buildKeyValueStore(resourceName, key string) string {
 	return resourceName + "." + key
 }
 

--- a/internal/helpers/testsacc/testsacc.go
+++ b/internal/helpers/testsacc/testsacc.go
@@ -303,6 +303,11 @@ func GenerateTests(tacc TestACC) []resource.TestStep {
 	return steps
 }
 
+// GenerateTestChecks Generate the checks for a specific test.
+func GenerateTestChecks(ctx context.Context, tacc TestACC, resourceName string, testName TestName) []resource.TestCheckFunc {
+	return tacc.Tests(ctx)[testName](ctx, resourceName).GenerateCheckWithCommonChecks()
+}
+
 // * Other
 
 // ImportStateIDBuilder is a function that can be used to dynamically generate

--- a/internal/testsacc/vdc_datasource_test.go
+++ b/internal/testsacc/vdc_datasource_test.go
@@ -3,13 +3,11 @@ package testsacc
 
 import (
 	"context"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/testsacc"
-	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/pkg/uuid"
 )
 
 var _ testsacc.TestACC = &VDCDataSource{}
@@ -37,7 +35,7 @@ func (r *VDCDataSource) DependenciesConfig() (configs testsacc.TFData) {
 func (r *VDCDataSource) Tests(ctx context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
 	return map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test{
 		// * Test One (example)
-		"example": func(_ context.Context, resourceName string) testsacc.Test {
+		"example": func(_ context.Context, _ string) testsacc.Test {
 			return testsacc.Test{
 				// ! Create testing
 				Create: testsacc.TFConfig{
@@ -45,28 +43,14 @@ func (r *VDCDataSource) Tests(ctx context.Context) map[testsacc.TestName]func(ct
 					data "cloudavenue_vdc" "example" {
 						name = cloudavenue_vdc.example.name
 					}`,
-					// TODO: Bug to get value from template in dependencies issue #543
-					// Checks: NewVDCResourceTest().Tests(ctx)["example"](ctx, resourceName).GenerateCheckWithCommonChecks(),
-					Checks: []resource.TestCheckFunc{
-						resource.TestMatchResourceAttr(resourceName, "id", regexp.MustCompile(uuid.VDC.String()+`[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}`)),
-						resource.TestCheckResourceAttrSet(resourceName, "name"),
-						resource.TestCheckResourceAttrSet(resourceName, "description"),
-						resource.TestCheckResourceAttrSet(resourceName, "service_class"),
-						resource.TestCheckResourceAttrSet(resourceName, "disponibility_class"),
-						resource.TestCheckResourceAttrSet(resourceName, "billing_model"),
-						resource.TestCheckResourceAttrSet(resourceName, "cpu_speed_in_mhz"),
-						resource.TestCheckResourceAttrSet(resourceName, "cpu_allocated"),
-						resource.TestCheckResourceAttrSet(resourceName, "memory_allocated"),
-						resource.TestCheckResourceAttrSet(resourceName, "storage_billing_model"),
-						resource.TestCheckResourceAttr(resourceName, "storage_profiles.#", "1"),
-					},
+					Checks: GetResourceConfig()[VDCResourceName]().GetDefaultChecks(),
 				},
 			}
 		},
 	}
 }
 
-func TestVDCDataSource(t *testing.T) {
+func TestAccVDCDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,


### PR DESCRIPTION
### Description of your changes

Fix #543 

### How has this code been tested

```
=== RUN   TestVDCDataSource
--- PASS: TestVDCDataSource (87.90s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  88.453s
```