### PR TITLE
chore!: remove attribute `vdc_group` ressource/datasource `_vdc`

### DIFF
--- a/.changelog/447.txt
+++ b/.changelog/447.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+`resource/cloudavenue_vdc` - Announced in the release [v0.0.9](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/releases/tag/v0.9.0) the attribute `vdc_group` is now **removed**.
+```
+
+```release-note:breaking-change
+`datasource/cloudavenue_vdc` - The `vdc_group` attribute is now **removed**.
+```

--- a/docs/data-sources/vdc.md
+++ b/docs/data-sources/vdc.md
@@ -42,9 +42,6 @@ output "example" {
 - `service_class` (String) The service class of the vDC.
 - `storage_billing_model` (String) Choose Billing model of storage resources.
 - `storage_profiles` (Attributes Set) List of storage profiles for this vDC. (see [below for nested schema](#nestedatt--storage_profiles))
-- `vdc_group` (String, Deprecated) vDC group name. 
-
- ~> **Attribute deprecated** Remove the `vdc_group` attribute configurationas it replaced by the resource [`cloudavenue_vdc_group`](https://registry.terraform.io/providers/orange-cloudavenue/cloudavenue/latest/docs/resources/vdc_group), it will be removed in the version [`v0.12.0`](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/4) of the provider. See the [GitHub issue](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/448) for more information.
 
 <a id="nestedatt--storage_profiles"></a>
 ### Nested Schema for `storage_profiles`

--- a/docs/resources/vdc.md
+++ b/docs/resources/vdc.md
@@ -61,10 +61,6 @@ resource "cloudavenue_vdc" "example" {
 
 - `description` (String) A description of the vDC.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
-- `vdc_group` (String, Deprecated) (ForceNew) vDC group name. This can be an existing vDC group or a new one. This allows you to isolate your vDC.
-VMs of vDCs which belong to the same vDC group can communicate together. 
-
- ~> **Attribute deprecated** Remove the `vdc_group` attribute configurationas it replaced by the resource [`cloudavenue_vdc_group`](https://registry.terraform.io/providers/orange-cloudavenue/cloudavenue/latest/docs/resources/vdc_group), it will be removed in the version [`v0.12.0`](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/4) of the provider. See the [GitHub issue](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/448) for more information.
 
 ### Read-Only
 

--- a/internal/provider/vdc/vdc_datasource.go
+++ b/internal/provider/vdc/vdc_datasource.go
@@ -114,7 +114,6 @@ func (d *vdcDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	}
 
 	data.ID.Set(ID)
-	data.VDCGroup.Set(vdc.VdcGroup)
 	data.Name.Set(vdc.Vdc.Name)
 	data.Description.Set(vdc.Vdc.Description)
 	data.VDCServiceClass.Set(vdc.Vdc.VdcServiceClass)

--- a/internal/provider/vdc/vdc_schema.go
+++ b/internal/provider/vdc/vdc_schema.go
@@ -137,33 +137,6 @@ func vdcSchema() superschema.Schema {
 					Computed: true,
 				},
 			},
-			"vdc_group": superschema.SuperStringAttribute{
-				Deprecated: &superschema.Deprecated{
-					DeprecationMessage:                "Remove the vdc_group attribute configuration as it replaced by the resource cloudavenue_vdc_group and the attribute will be removed in the version 0.12.0 of the provider.",
-					ComputeMarkdownDeprecationMessage: true,
-					Removed:                           true,
-					FromAttributeName:                 "vdc_group",
-					TargetRelease:                     "v0.12.0",
-					LinkToMilestone:                   "https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/4",
-					TargetResourceName:                "cloudavenue_vdc_group",
-					LinkToResourceDoc:                 "https://registry.terraform.io/providers/orange-cloudavenue/cloudavenue/latest/docs/resources/vdc_group",
-					LinkToIssue:                       "https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/448",
-				},
-				Common: &schemaR.StringAttribute{
-					MarkdownDescription: "vDC group name.",
-				},
-				Resource: &schemaR.StringAttribute{
-					MarkdownDescription: "This can be an existing vDC group or a new one. This allows you to isolate your vDC.\n" +
-						"VMs of vDCs which belong to the same vDC group can communicate together.",
-					Optional: true,
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.RequiresReplaceIfConfigured(),
-					},
-				},
-				DataSource: &schemaD.StringAttribute{
-					Computed: true,
-				},
-			},
 			"service_class": superschema.SuperStringAttribute{
 				Common: &schemaR.StringAttribute{
 					MarkdownDescription: "The service class of the vDC.",

--- a/internal/provider/vdc/vdc_types.go
+++ b/internal/provider/vdc/vdc_types.go
@@ -23,7 +23,6 @@ type vdcResourceModel struct {
 	MemoryAllocated        supertypes.Int64Value     `tfsdk:"memory_allocated"`
 	VDCStorageBillingModel supertypes.StringValue    `tfsdk:"storage_billing_model"`
 	VDCStorageProfiles     supertypes.SetNestedValue `tfsdk:"storage_profiles"`
-	VDCGroup               supertypes.StringValue    `tfsdk:"vdc_group"`
 }
 
 // * VDCStorageProfiles.
@@ -48,7 +47,6 @@ type vdcDataSourceModel struct {
 	MemoryAllocated        supertypes.Int64Value     `tfsdk:"memory_allocated"`
 	VDCStorageBillingModel supertypes.StringValue    `tfsdk:"storage_billing_model"`
 	VDCStorageProfiles     supertypes.SetNestedValue `tfsdk:"storage_profiles"`
-	VDCGroup               supertypes.StringValue    `tfsdk:"vdc_group"`
 }
 
 // * VDCStorageProfiles.


### PR DESCRIPTION
### Description of your changes

remove attribute `vdc_group` ressource/datasource `cloudavenue_vdc`

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
=== RUN   TestAccVDCResource
--- PASS: TestAccVDCResource (148.71s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  149.371s
```