### PR TITLE
chore: bump VCD API Version from 37.1 to 37.2

### DIFF
--- a/.changelog/562.txt
+++ b/.changelog/562.txt
@@ -1,0 +1,3 @@
+```release-note:note
+bump VCD API Version from 37.1 to 37.2
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -16,7 +16,7 @@ import (
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/client"
 )
 
-const VCDVersion = "37.1"
+const VCDVersion = "37.2"
 
 // Ensure the implementation satisfies the expected interfaces.
 var _ provider.Provider = &cloudavenueProvider{}


### PR DESCRIPTION

### Description of your changes

bump VCD API Version from 37.1 to 37.2