### PR TITLE
chore: refacto testsacc `_catalog` datasource

### DIFF
--- a/internal/testsacc/acctest_datasources_test.go
+++ b/internal/testsacc/acctest_datasources_test.go
@@ -4,6 +4,13 @@ import "github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/he
 
 func GetDataSourceConfig() map[testsacc.ResourceName]func() resourceConfig {
 	return map[testsacc.ResourceName]func() resourceConfig{
+		// * Catalog
+		CatalogDataSourceName:             NewResourceConfig(NewCatalogDataSourceTest()),
+		CatalogACLDataSourceName:          NewResourceConfig(NewCatalogACLDataSourceTest()),
+		CatalogsDataSourceName:            NewResourceConfig(NewCatalogsDataSourceTest()),
+		CatalogVAppTemplateDataSourceName: NewResourceConfig(NewCatalogVAppTemplateDataSourceTest()),
+
+		// * Tier0
 		Tier0VRFDataSourceName: NewResourceConfig(NewTier0VRFDataSourceTest()),
 
 		// * VDC

--- a/internal/testsacc/catalog_vapp_template_datasource_test.go
+++ b/internal/testsacc/catalog_vapp_template_datasource_test.go
@@ -2,44 +2,70 @@
 package testsacc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/testsacc"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/pkg/uuid"
 )
 
-//go:generate tf-doc-extractor -filename $GOFILE -example-dir ../../../examples -test
-const testAccCatalogVappTemplateDataSourceConfig = `
-data "cloudavenue_catalog_vapp_template" "example" {
-	catalog_name  	= "Orange-Linux"
-	template_name 	= "UBUNTU_20.04"
+var _ testsacc.TestACC = &CatalogVAppTemplateDataSource{}
+
+const (
+	CatalogVAppTemplateDataSourceName = testsacc.ResourceName("data.cloudavenue_catalog_vapp_template")
+)
+
+type CatalogVAppTemplateDataSource struct{}
+
+func NewCatalogVAppTemplateDataSourceTest() testsacc.TestACC {
+	return &CatalogVAppTemplateDataSource{}
 }
-`
 
-func TestAccCatalogVappTemplateDataSource(t *testing.T) {
-	dataSourceName := "data.cloudavenue_catalog_vapp_template.example"
+// GetResourceName returns the name of the resource.
+func (r *CatalogVAppTemplateDataSource) GetResourceName() string {
+	return CatalogVAppTemplateDataSourceName.String()
+}
 
+func (r *CatalogVAppTemplateDataSource) DependenciesConfig() (resp testsacc.DependenciesConfigResponse) {
+	return
+}
+
+func (r *CatalogVAppTemplateDataSource) Tests(ctx context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
+	return map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test{
+		// * Test One (example)
+		"example": func(_ context.Context, resourceName string) testsacc.Test {
+			return testsacc.Test{
+				// ! Create testing
+				Create: testsacc.TFConfig{
+					TFConfig: `
+					data "cloudavenue_catalog_vapp_template" "example" {
+						catalog_name  	= "Orange-Linux"
+						template_name 	= "UBUNTU_20.04"
+					}`,
+					Checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttrWith(resourceName, "id", uuid.TestIsType(uuid.VAPPTemplate)),
+						// Catalog
+						resource.TestCheckResourceAttr(resourceName, "catalog_name", "Orange-Linux"),
+						resource.TestCheckResourceAttrWith(resourceName, "catalog_id", uuid.TestIsType(uuid.Catalog)),
+
+						resource.TestCheckResourceAttr(resourceName, "template_name", "UBUNTU_20.04"),
+						resource.TestCheckResourceAttrWith(resourceName, "template_id", uuid.TestIsType(uuid.VAPPTemplate)),
+						// Other
+						resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+						resource.TestCheckResourceAttrSet(resourceName, "vm_names.#"),
+					},
+				},
+			}
+		},
+	}
+}
+
+func TestACCCatalogVAppTemplateDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Read testing
-			{
-				Config: testAccCatalogVappTemplateDataSourceConfig,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrWith(dataSourceName, "id", uuid.TestIsType(uuid.VAPPTemplate)),
-					// Catalog
-					resource.TestCheckResourceAttr(dataSourceName, "catalog_name", "Orange-Linux"),
-					resource.TestCheckResourceAttrWith(dataSourceName, "catalog_id", uuid.TestIsType(uuid.Catalog)),
-
-					resource.TestCheckResourceAttr(dataSourceName, "template_name", "UBUNTU_20.04"),
-					resource.TestCheckResourceAttrWith(dataSourceName, "template_id", uuid.TestIsType(uuid.VAPPTemplate)),
-					// Other
-					resource.TestCheckResourceAttrSet(dataSourceName, "created_at"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "vm_names.#"),
-				),
-			},
-		},
+		Steps:                    testsacc.GenerateTests(&CatalogVAppTemplateDataSource{}),
 	})
 }

--- a/internal/testsacc/catalogs_datasource_test.go
+++ b/internal/testsacc/catalogs_datasource_test.go
@@ -2,47 +2,73 @@
 package testsacc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/testsacc"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/pkg/uuid"
 )
 
-const testAccCatalogsDataSourceConfig = `
-data "cloudavenue_catalogs" "example" {}
-`
+var _ testsacc.TestACC = &CatalogsDataSource{}
 
-func TestAccCatalogsDataSource(t *testing.T) {
-	dataSourceName := "data.cloudavenue_catalogs.example"
+const (
+	CatalogsDataSourceName = testsacc.ResourceName("data.cloudavenue_catalogs")
+)
 
+type CatalogsDataSource struct{}
+
+func NewCatalogsDataSourceTest() testsacc.TestACC {
+	return &CatalogsDataSource{}
+}
+
+// GetResourceName returns the name of the resource.
+func (r *CatalogsDataSource) GetResourceName() string {
+	return CatalogsDataSourceName.String()
+}
+
+func (r *CatalogsDataSource) DependenciesConfig() (resp testsacc.DependenciesConfigResponse) {
+	return
+}
+
+func (r *CatalogsDataSource) Tests(ctx context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
+	return map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test{
+		// * Test One (example)
+		"example": func(_ context.Context, resourceName string) testsacc.Test {
+			return testsacc.Test{
+				// ! Create testing
+				Create: testsacc.TFConfig{
+					TFConfig: `data "cloudavenue_catalogs" "example" {}`,
+					Checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttrSet(resourceName, "id"),
+						resource.TestCheckResourceAttrSet(resourceName, "catalogs_name.#"),
+						resource.TestCheckResourceAttrSet(resourceName, "catalogs.%"),
+
+						resource.TestCheckResourceAttrWith(resourceName, "catalogs.Orange-Linux.id", uuid.TestIsType(uuid.Catalog)),
+						resource.TestCheckResourceAttrSet(resourceName, "catalogs.Orange-Linux.name"),
+						resource.TestCheckResourceAttrSet(resourceName, "catalogs.Orange-Linux.created_at"),
+						resource.TestCheckResourceAttrSet(resourceName, "catalogs.Orange-Linux.preserve_identity_information"),
+						resource.TestCheckResourceAttrSet(resourceName, "catalogs.Orange-Linux.number_of_media"),
+						resource.TestCheckResourceAttrSet(resourceName, "catalogs.Orange-Linux.media_item_list.#"),
+						resource.TestCheckResourceAttrSet(resourceName, "catalogs.Orange-Linux.is_shared"),
+						resource.TestCheckResourceAttrSet(resourceName, "catalogs.Orange-Linux.is_published"),
+						resource.TestCheckResourceAttrSet(resourceName, "catalogs.Orange-Linux.is_local"),
+
+						resource.TestCheckNoResourceAttr(resourceName, "catalogs.Orange-Linux.owner_name"),  // In Orange-Linux catalog, owner_name is empty
+						resource.TestCheckNoResourceAttr(resourceName, "catalogs.Orange-Linux.description"), // In Orange-Linux catalog, description is empty
+						resource.TestCheckNoResourceAttr(resourceName, "catalogs.Orange-Linux.is_cached"),   // In Orange-Linux catalog, is_cached is false
+					},
+				},
+			}
+		},
+	}
+}
+
+func TestACCCatalogsDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Read testing
-			{
-				Config: testAccCatalogsDataSourceConfig,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "catalogs_name.#"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "catalogs.%"),
-
-					resource.TestCheckResourceAttrWith(dataSourceName, "catalogs.Orange-Linux.id", uuid.TestIsType(uuid.Catalog)),
-					resource.TestCheckResourceAttrSet(dataSourceName, "catalogs.Orange-Linux.name"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "catalogs.Orange-Linux.created_at"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "catalogs.Orange-Linux.preserve_identity_information"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "catalogs.Orange-Linux.number_of_media"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "catalogs.Orange-Linux.media_item_list.#"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "catalogs.Orange-Linux.is_shared"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "catalogs.Orange-Linux.is_published"),
-					resource.TestCheckResourceAttrSet(dataSourceName, "catalogs.Orange-Linux.is_local"),
-
-					resource.TestCheckNoResourceAttr(dataSourceName, "catalogs.Orange-Linux.owner_name"),  // In Orange-Linux catalog, owner_name is empty
-					resource.TestCheckNoResourceAttr(dataSourceName, "catalogs.Orange-Linux.description"), // In Orange-Linux catalog, description is empty
-					resource.TestCheckNoResourceAttr(dataSourceName, "catalogs.Orange-Linux.is_cached"),   // In Orange-Linux catalog, is_cached is false
-				),
-			},
-		},
+		Steps:                    testsacc.GenerateTests(&CatalogsDataSource{}),
 	})
 }


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [ ] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [ ] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
--- PASS: TestAccCatalogDataSource (19.84s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  20.142s

--- PASS: TestACCCatalogVAppTemplateDataSource (15.74s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  16.505s

--- PASS: TestACCCatalogsDataSource (14.84s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  15.373s


```