### PR TITLE
fix: nil pointer in catalog datasource

### DIFF
--- a/internal/provider/catalog/catalog_datasource.go
+++ b/internal/provider/catalog/catalog_datasource.go
@@ -111,9 +111,10 @@ func (d *catalogDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	}
 
 	if catalog.AdminCatalog.PublishExternalCatalogParams != nil {
-		updatedState.IsCached = types.BoolValue(*catalog.AdminCatalog.PublishExternalCatalogParams.IsCachedEnabled)
-		updatedState.IsShared = types.BoolValue(*catalog.AdminCatalog.PublishExternalCatalogParams.IsPublishedExternally)
-		updatedState.PreserveIdentityInformation = types.BoolValue(*catalog.AdminCatalog.PublishExternalCatalogParams.PreserveIdentityInfoFlag)
+		// Fx Issue #657 - The IsCachedEnabled flag is not always set. Now use BoolPointerValue to avoid panic
+		updatedState.IsCached = types.BoolPointerValue(catalog.AdminCatalog.PublishExternalCatalogParams.IsCachedEnabled)
+		updatedState.IsShared = types.BoolPointerValue(catalog.AdminCatalog.PublishExternalCatalogParams.IsPublishedExternally)
+		updatedState.PreserveIdentityInformation = types.BoolPointerValue(catalog.AdminCatalog.PublishExternalCatalogParams.PreserveIdentityInfoFlag)
 	}
 
 	var (


### PR DESCRIPTION
### Description of your changes

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
=== RUN   TestAccCatalogDataSource
2023/12/19 15:24:32 TestACC: execution ID is testacc_53cdf1a2-9e7a-11ee-88e2-7a8bf7ef3cc0
--- PASS: TestAccCatalogDataSource (22.97s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  23.486s
```