### PR TITLE
feat!: remove `lb_enabled` attribute in edgegw resource/datasource

### DIFF
--- a/.changelog/575.txt
+++ b/.changelog/575.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+`resource/cloudavenue_edgegateway` - Announced in release [v0.14.0](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/releases/tag/v0.14.0) the attribute `lb_enabled` is now removed.
+```
+
+```release-note:breaking-change
+`datasource/cloudavenue_edgegateway` - Announced in release [v0.14.0](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/releases/tag/v0.14.0) the attribute `lb_enabled` is now removed.
+```

--- a/docs/data-sources/edgegateway.md
+++ b/docs/data-sources/edgegateway.md
@@ -33,9 +33,6 @@ output "gateway" {
 - `bandwidth` (Number) The bandwidth in Mbps of the Edge Gateway.
 - `description` (String) The description of the Edge Gateway.
 - `id` (String) The ID of the Edge Gateway.
-- `lb_enabled` (Boolean, Deprecated) Load Balancing state on the Edge Gateway. 
-
- ~> **Attribute deprecated** Remove the `lb_enabled` attribute configuration, it will be removed in the version [`v0.16.0`](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/8) of the provider. See the [GitHub issue](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/567) for more information.
 - `owner_name` (String) The name of the Edge Gateway owner.
 - `owner_type` (String) The type of the Edge Gateway owner. Value must be one of : `vdc`, `vdc-group`.
 - `tier0_vrf_name` (String) The name of the Tier-0 VRF to which the Edge Gateway is attached.

--- a/docs/resources/edgegateway.md
+++ b/docs/resources/edgegateway.md
@@ -43,9 +43,6 @@ resource "cloudavenue_edgegateway" "example" {
 ### Optional
 
 - `bandwidth` (Number) The bandwidth in Mbps of the Edge Gateway. If no value is not specified, the bandwidth is automatically calculated based on the remaining bandwidth of the Tier-0 VRF.
-- `lb_enabled` (Boolean, Deprecated) Load Balancing state on the Edge Gateway. 
-
- ~> **Attribute deprecated** Remove the `lb_enabled` attribute configuration, it will be removed in the version [`v0.16.0`](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/8) of the provider. See the [GitHub issue](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/567) for more information.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only

--- a/examples/resources/cloudavenue_edgegateway/resource.tf
+++ b/examples/resources/cloudavenue_edgegateway/resource.tf
@@ -1,7 +1,0 @@
-data "cloudavenue_tier0_vrfs" "example_with_vdc" {}
-
-resource "cloudavenue_edgegateway" "example" {
-  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example_with_vdc.names.0
-  owner_name     = "MyVDC"
-  owner_type     = "vdc"
-}

--- a/internal/provider/edgegw/edgegateway_datasource.go
+++ b/internal/provider/edgegw/edgegateway_datasource.go
@@ -81,11 +81,6 @@ func (d *edgeGatewayDataSource) Read(ctx context.Context, req datasource.ReadReq
 	data.Description.Set(edgegw.GetDescription())
 	data.Bandwidth.SetInt(int(edgegw.GetBandwidth()))
 
-	// EnableLoadBalancing is now deprecated, but we still need to set it to false if it is unknown
-	if !data.EnableLoadBalancing.IsKnown() {
-		data.EnableLoadBalancing.Set(false)
-	}
-
 	// Set refreshed state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/edgegw/edgegateway_resource.go
+++ b/internal/provider/edgegw/edgegateway_resource.go
@@ -515,10 +515,5 @@ func (r *edgeGatewayResource) read(_ context.Context, planOrState *edgeGatewayRe
 	stateRefreshed.Description.Set(edgegw.GetDescription())
 	stateRefreshed.Bandwidth.SetInt(int(edgegw.GetBandwidth()))
 
-	// EnableLoadBalancing is now deprecated, but we still need to set it to false if it is unknown
-	if !stateRefreshed.EnableLoadBalancing.IsKnown() {
-		stateRefreshed.EnableLoadBalancing.Set(false)
-	}
-
 	return stateRefreshed, true, nil
 }

--- a/internal/provider/edgegw/edgegateway_schema.go
+++ b/internal/provider/edgegw/edgegateway_schema.go
@@ -130,24 +130,6 @@ func edgegwSchema() superschema.Schema {
 					MarkdownDescription: "If no value is not specified, the bandwidth is automatically calculated based on the remaining bandwidth of the Tier-0 VRF.",
 				},
 			},
-			"lb_enabled": &superschema.SuperBoolAttribute{
-				Deprecated: &superschema.Deprecated{
-					DeprecationMessage:                "Remove the lb_enabled attribute configuration and the attribute will be removed in the version 0.16.0 of the provider. This field have does not work and will be replaced soon by a new resource.",
-					ComputeMarkdownDeprecationMessage: true,
-					Removed:                           true,
-					FromAttributeName:                 "lb_enabled",
-					TargetRelease:                     "v0.16.0",
-					LinkToMilestone:                   "https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/8",
-					LinkToIssue:                       "https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/567",
-				},
-				Common: &schemaR.BoolAttribute{
-					MarkdownDescription: "Load Balancing state on the Edge Gateway.",
-					Computed:            true,
-				},
-				Resource: &schemaR.BoolAttribute{
-					Optional: true,
-				},
-			},
 		},
 	}
 }

--- a/internal/provider/edgegw/edgegateway_types.go
+++ b/internal/provider/edgegw/edgegateway_types.go
@@ -9,26 +9,24 @@ import (
 )
 
 type edgeGatewayResourceModel struct {
-	Timeouts            timeouts.Value         `tfsdk:"timeouts"`
-	ID                  supertypes.StringValue `tfsdk:"id"`
-	Tier0VrfID          supertypes.StringValue `tfsdk:"tier0_vrf_name"`
-	Name                supertypes.StringValue `tfsdk:"name"`
-	OwnerType           supertypes.StringValue `tfsdk:"owner_type"`
-	OwnerName           supertypes.StringValue `tfsdk:"owner_name"`
-	Description         supertypes.StringValue `tfsdk:"description"`
-	EnableLoadBalancing supertypes.BoolValue   `tfsdk:"lb_enabled"`
-	Bandwidth           supertypes.Int64Value  `tfsdk:"bandwidth"`
+	Timeouts    timeouts.Value         `tfsdk:"timeouts"`
+	ID          supertypes.StringValue `tfsdk:"id"`
+	Tier0VrfID  supertypes.StringValue `tfsdk:"tier0_vrf_name"`
+	Name        supertypes.StringValue `tfsdk:"name"`
+	OwnerType   supertypes.StringValue `tfsdk:"owner_type"`
+	OwnerName   supertypes.StringValue `tfsdk:"owner_name"`
+	Description supertypes.StringValue `tfsdk:"description"`
+	Bandwidth   supertypes.Int64Value  `tfsdk:"bandwidth"`
 }
 
 type edgeGatewayDatasourceModel struct {
-	ID                  supertypes.StringValue `tfsdk:"id"`
-	Tier0VrfID          supertypes.StringValue `tfsdk:"tier0_vrf_name"`
-	Name                supertypes.StringValue `tfsdk:"name"`
-	OwnerType           supertypes.StringValue `tfsdk:"owner_type"`
-	OwnerName           supertypes.StringValue `tfsdk:"owner_name"`
-	Description         supertypes.StringValue `tfsdk:"description"`
-	EnableLoadBalancing supertypes.BoolValue   `tfsdk:"lb_enabled"`
-	Bandwidth           supertypes.Int64Value  `tfsdk:"bandwidth"`
+	ID          supertypes.StringValue `tfsdk:"id"`
+	Tier0VrfID  supertypes.StringValue `tfsdk:"tier0_vrf_name"`
+	Name        supertypes.StringValue `tfsdk:"name"`
+	OwnerType   supertypes.StringValue `tfsdk:"owner_type"`
+	OwnerName   supertypes.StringValue `tfsdk:"owner_name"`
+	Description supertypes.StringValue `tfsdk:"description"`
+	Bandwidth   supertypes.Int64Value  `tfsdk:"bandwidth"`
 }
 
 // Copy returns a copy of the edgeGatewayResourceModel.

--- a/internal/testsacc/edgegw_edgegateway_resource_test.go
+++ b/internal/testsacc/edgegw_edgegateway_resource_test.go
@@ -21,7 +21,6 @@ resource "cloudavenue_edgegateway" "example_with_vdc" {
   owner_name     = "MyEdgeGateway"
   tier0_vrf_name = data.cloudavenue_tier0_vrfs.example_with_vdc.names.0
   owner_type     = "vdc"
-  lb_enabled     = false
 }
 `
 
@@ -84,7 +83,6 @@ func (r *EdgeGatewayResource) Tests(ctx context.Context) map[testsacc.TestName]f
 					}`),
 					Checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttrSet(resourceName, "bandwidth"),
-						resource.TestCheckResourceAttr(resourceName, "lb_enabled", "false"), // Deprecated attribute
 					},
 				},
 				// ! Updates testing
@@ -130,7 +128,6 @@ func (r *EdgeGatewayResource) Tests(ctx context.Context) map[testsacc.TestName]f
 						  }`),
 						Checks: []resource.TestCheckFunc{
 							resource.TestCheckResourceAttr(resourceName, "bandwidth", "5"),
-							resource.TestCheckResourceAttr(resourceName, "lb_enabled", "false"),
 						},
 					},
 				},
@@ -163,9 +160,7 @@ func (r *EdgeGatewayResource) Tests(ctx context.Context) map[testsacc.TestName]f
 						tier0_vrf_name = data.cloudavenue_tier0_vrf.example.name
 						owner_type     = "vdc-group"
 					  }`),
-					Checks: []resource.TestCheckFunc{
-						resource.TestCheckResourceAttr(resourceName, "lb_enabled", "false"),
-					},
+					Checks: []resource.TestCheckFunc{},
 				},
 				// ! Updates testing
 				Updates: []testsacc.TFConfig{
@@ -179,7 +174,6 @@ func (r *EdgeGatewayResource) Tests(ctx context.Context) map[testsacc.TestName]f
 						  }`),
 						Checks: []resource.TestCheckFunc{
 							resource.TestCheckResourceAttr(resourceName, "bandwidth", "5"),
-							resource.TestCheckResourceAttr(resourceName, "lb_enabled", "false"),
 						},
 					},
 				},


### PR DESCRIPTION
### Description of your changes

Remove attribute `lb_enabled` for resource and datasource cloudavenue_edgegateway

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
--- PASS: TestAccEdgeGatewayResource (1375.73s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  1376.566s
```