### PR TITLE
chore: refacto `tier0_vrf` and `tier0_vrfs` datasource to new SDK

### DIFF
--- a/internal/provider/vrf/tier0_vrf_schema.go
+++ b/internal/provider/vrf/tier0_vrf_schema.go
@@ -16,7 +16,7 @@ func tier0VrfSchema() superschema.Schema {
 			MarkdownDescription: "data source retrieve informations about a Tier-0 VRF.",
 		},
 		Attributes: map[string]superschema.Attribute{
-			"id": superschema.StringAttribute{
+			"id": superschema.SuperStringAttribute{
 				Common: &schemaR.StringAttribute{
 					MarkdownDescription: "The ID of the Tier-0 VRF.",
 				},
@@ -24,7 +24,7 @@ func tier0VrfSchema() superschema.Schema {
 					Computed: true,
 				},
 			},
-			"name": superschema.StringAttribute{
+			"name": superschema.SuperStringAttribute{
 				Common: &schemaR.StringAttribute{
 					MarkdownDescription: "The name of the Tier-0 VRF.",
 				},
@@ -32,7 +32,7 @@ func tier0VrfSchema() superschema.Schema {
 					Required: true,
 				},
 			},
-			"tier0_provider": superschema.StringAttribute{
+			"tier0_provider": superschema.SuperStringAttribute{
 				Common: &schemaR.StringAttribute{
 					MarkdownDescription: "Tier-0 provider info.",
 				},
@@ -40,7 +40,7 @@ func tier0VrfSchema() superschema.Schema {
 					Computed: true,
 				},
 			},
-			"class_service": superschema.StringAttribute{
+			"class_service": superschema.SuperStringAttribute{
 				Common: &schemaR.StringAttribute{
 					MarkdownDescription: "List of Tags for the Tier-0 VRF.",
 				},
@@ -48,7 +48,7 @@ func tier0VrfSchema() superschema.Schema {
 					Computed: true,
 				},
 			},
-			"services": superschema.ListNestedAttribute{
+			"services": superschema.SuperListNestedAttributeOf[segmentModel]{
 				Common: &schemaR.ListNestedAttribute{
 					MarkdownDescription: "Services list of the Tier-0 VRF.",
 				},
@@ -56,7 +56,7 @@ func tier0VrfSchema() superschema.Schema {
 					Computed: true,
 				},
 				Attributes: superschema.Attributes{
-					"service": superschema.StringAttribute{
+					"service": superschema.SuperStringAttribute{
 						Common: &schemaR.StringAttribute{
 							MarkdownDescription: "Service of the segment.",
 						},
@@ -64,7 +64,7 @@ func tier0VrfSchema() superschema.Schema {
 							Computed: true,
 						},
 					},
-					"vlan_id": superschema.StringAttribute{
+					"vlan_id": superschema.SuperStringAttribute{
 						Common: &schemaR.StringAttribute{
 							MarkdownDescription: "VLAN ID of the segment.",
 						},

--- a/internal/provider/vrf/tier0_vrf_types.go
+++ b/internal/provider/vrf/tier0_vrf_types.go
@@ -1,16 +1,16 @@
 package vrf
 
-import "github.com/hashicorp/terraform-plugin-framework/types"
+import supertypes "github.com/FrangipaneTeam/terraform-plugin-framework-supertypes"
 
 type tier0VrfDataSourceModel struct {
-	ID           types.String   `tfsdk:"id"`
-	Name         types.String   `tfsdk:"name"`
-	Provider     types.String   `tfsdk:"tier0_provider"`
-	ClassService types.String   `tfsdk:"class_service"`
-	Services     []segmentModel `tfsdk:"services"`
+	ID           supertypes.StringValue                           `tfsdk:"id"`
+	Name         supertypes.StringValue                           `tfsdk:"name"`
+	Provider     supertypes.StringValue                           `tfsdk:"tier0_provider"`
+	ClassService supertypes.StringValue                           `tfsdk:"class_service"`
+	Services     supertypes.ListNestedObjectValueOf[segmentModel] `tfsdk:"services"`
 }
 
 type segmentModel struct {
-	Service types.String `tfsdk:"service"`
-	VLANID  types.String `tfsdk:"vlan_id"`
+	Service supertypes.StringValue `tfsdk:"service"`
+	VLANID  supertypes.StringValue `tfsdk:"vlan_id"`
 }

--- a/internal/provider/vrf/tier0_vrfs_schema.go
+++ b/internal/provider/vrf/tier0_vrfs_schema.go
@@ -1,12 +1,11 @@
 package vrf
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/types"
-
 	schemaD "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	schemaR "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	superschema "github.com/FrangipaneTeam/terraform-plugin-framework-superschema"
+	supertypes "github.com/FrangipaneTeam/terraform-plugin-framework-supertypes"
 )
 
 func tier0VrfsSchema() superschema.Schema {
@@ -18,8 +17,8 @@ func tier0VrfsSchema() superschema.Schema {
 			MarkdownDescription: "data source allow access to a list of Tier-0 that can be accessed by the user.",
 		},
 
-		Attributes: map[string]superschema.Attribute{
-			"id": superschema.StringAttribute{
+		Attributes: superschema.Attributes{
+			"id": superschema.SuperStringAttribute{
 				Common: &schemaR.StringAttribute{
 					MarkdownDescription: "The ID of the Tier-0 VRFs.",
 				},
@@ -27,12 +26,12 @@ func tier0VrfsSchema() superschema.Schema {
 					Computed: true,
 				},
 			},
-			"names": superschema.ListAttribute{
+			"names": superschema.SuperListAttributeOf[string]{
 				Common: &schemaR.ListAttribute{
 					MarkdownDescription: "List of Tier-0 VRFs names.",
 				},
 				DataSource: &schemaD.ListAttribute{
-					ElementType: types.StringType,
+					ElementType: supertypes.StringType{},
 					Computed:    true,
 				},
 			},

--- a/internal/provider/vrf/tier0_vrfs_types.go
+++ b/internal/provider/vrf/tier0_vrfs_types.go
@@ -1,8 +1,8 @@
 package vrf
 
-import "github.com/hashicorp/terraform-plugin-framework/types"
+import supertypes "github.com/FrangipaneTeam/terraform-plugin-framework-supertypes"
 
 type tier0VrfsDataSourceModel struct {
-	ID    types.String   `tfsdk:"id"`
-	Names []types.String `tfsdk:"names"`
+	ID    supertypes.StringValue         `tfsdk:"id"`
+	Names supertypes.ListValueOf[string] `tfsdk:"names"`
 }

--- a/internal/testsacc/tier0_vrf_datasource_test.go
+++ b/internal/testsacc/tier0_vrf_datasource_test.go
@@ -3,6 +3,7 @@ package testsacc
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -44,16 +45,10 @@ func (r *Tier0VRFDataSource) Tests(ctx context.Context) map[testsacc.TestName]fu
 					}`,
 					Checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttrSet(resourceName, "id"),
-						resource.TestCheckResourceAttr(resourceName, "name", "prvrf01eocb0006205allsp01"),
+						resource.TestMatchResourceAttr(resourceName, "name", regexp.MustCompile("^prvrf[0-9]{2}eocb[0-9]{7}allsp[0-9]{2}")),
 						resource.TestCheckResourceAttr(resourceName, "class_service", "VRF_STANDARD"),
 						resource.TestCheckResourceAttr(resourceName, "tier0_provider", "pr01e02t0sp16"),
-						resource.TestCheckResourceAttr(resourceName, "services.#", "3"),
-						resource.TestCheckResourceAttr(resourceName, "services.0.service", "OBJECT_STORAGE"),
-						resource.TestCheckResourceAttr(resourceName, "services.0.vlan_id", ""),
-						resource.TestCheckResourceAttr(resourceName, "services.1.service", "INTERNET"),
-						resource.TestCheckResourceAttr(resourceName, "services.1.vlan_id", ""),
-						resource.TestCheckResourceAttr(resourceName, "services.2.service", "ADMIN"),
-						resource.TestCheckResourceAttr(resourceName, "services.2.vlan_id", ""),
+						resource.TestCheckResourceAttrSet(resourceName, "services.#"),
 					},
 				},
 			}

--- a/internal/testsacc/tier0_vrfs_datasource_test.go
+++ b/internal/testsacc/tier0_vrfs_datasource_test.go
@@ -2,28 +2,57 @@
 package testsacc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/testsacc"
 )
 
-const testAccTier0VrfsDataSourceConfig = `
-data "cloudavenue_tier0_vrfs" "test" {}
-`
+var _ testsacc.TestACC = &Tier0VRFsDataSource{}
+
+const (
+	Tier0VRFsDataSourceName = testsacc.ResourceName("data.cloudavenue_tier0_vrfs")
+)
+
+type Tier0VRFsDataSource struct{}
+
+func NewTier0VRFsDataSourceTest() testsacc.TestACC {
+	return &Tier0VRFsDataSource{}
+}
+
+// GetResourceName returns the name of the resource.
+func (r *Tier0VRFsDataSource) GetResourceName() string {
+	return Tier0VRFsDataSourceName.String()
+}
+
+func (r *Tier0VRFsDataSource) DependenciesConfig() (resp testsacc.DependenciesConfigResponse) {
+	return
+}
+
+func (r *Tier0VRFsDataSource) Tests(ctx context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
+	return map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test{
+		// * Test One (example)
+		"example": func(_ context.Context, resourceName string) testsacc.Test {
+			return testsacc.Test{
+				// ! Create testing
+				Create: testsacc.TFConfig{
+					TFConfig: `data "cloudavenue_tier0_vrfs" "example" {}`,
+					Checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttrSet(resourceName, "id"),
+						resource.TestCheckResourceAttrSet(resourceName, "names.#"),
+					},
+				},
+			}
+		},
+	}
+}
 
 func TestAccTier0VrfsDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Read testing.
-			{
-				Config: testAccTier0VrfsDataSourceConfig,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.cloudavenue_tier0_vrfs.test", "names.0", "prvrf01eocb0006205allsp01"),
-					resource.TestCheckResourceAttr("data.cloudavenue_tier0_vrfs.test", "id", "d767aafb-f919-5cc7-8d97-0287f2d672ab"),
-				),
-			},
-		},
+		Steps:                    testsacc.GenerateTests(&Tier0VRFsDataSource{}),
 	})
 }


### PR DESCRIPTION
### Description of your changes

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
=== RUN   TestAccTier0VrfDataSource
2024/01/22 15:38:47 TestACC: execution ID is testacc_f356d0bc-b933-11ee-8f54-7a8bf7ef3cc2
--- PASS: TestAccTier0VrfDataSource (16.65s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  17.376s

=== RUN   TestAccTier0VrfsDataSource
2024/01/22 15:48:35 TestACC: execution ID is testacc_51ee825e-b935-11ee-b3e2-7a8bf7ef3cc2
--- PASS: TestAccTier0VrfsDataSource (26.51s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  27.234s
```