### PR TITLE
fix: get edgegateway with UUID instead URN

### DIFF
--- a/.changelog/765.txt
+++ b/.changelog/765.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_edgegateway` - Fixed an issue with the Edge Gateway resource that could not be obtained with a URN instead of a UUID.
+```

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
@@ -14,7 +14,6 @@ linters:
     - errcheck # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases [fast: false, auto-fix: false]
     - errchkjson # Checks types passed to the json encoding functions. Reports unsupported types and optionally reports occasions, where the check for the returned error can be omitted. [fast: false, auto-fix: false]
     - errname # Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`. [fast: false, auto-fix: false]
-    - execinquery # execinquery is a linter about query string checker in Query function which reads your Go src files and warning it finds [fast: false, auto-fix: false]
     - exportloopref # checks for pointers to enclosing loop variables [fast: false, auto-fix: false]
     - forbidigo # Forbids identifiers [fast: true, auto-fix: false]
     - gci # Gci controls golang package import order and makes it always deterministic. [fast: true, auto-fix: false]
@@ -30,7 +29,6 @@ linters:
     - gosimple #(megacheck): Linter for Go source code that specializes in simplifying a code [fast: false, auto-fix: false]
     - govet #(vet, vetshadow): Vet examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string [fast: false, auto-fix: false]
     - grouper # An analyzer to analyze expression groups. [fast: true, auto-fix: false]
-    - ifshort # Checks that your code uses short syntax for if-statements whenever possible [fast: true, auto-fix: false]
     - importas # Enforces consistent import aliases [fast: false, auto-fix: false]
     - ineffassign # Detects when assignments to existing variables are not used [fast: true, auto-fix: false]
     - makezero # Finds slice declarations with non-zero initial length [fast: false, auto-fix: false]
@@ -63,9 +61,6 @@ linters:
 
   disable:
     - dupl # Tool for code clone detection [fast: true, auto-fix: false]
-    - varcheck # Finds unused global variables and constants [fast: false, auto-fix: false]
-    - deadcode # Finds unused code [fast: false, auto-fix: false]
-    - structcheck # Finds unused struct fields [fast: false, auto-fix: false]
     - nakedret # Finds naked returns in functions greater than a specified function length [fast: true, auto-fix: false]
     - depguard # Go linter that checks if package imports are in a list of acceptable packages [fast: true, auto-fix: false]
     - goimports # In addition to fixing imports, goimports also formats your code in the same style as gofmt. [fast: true, auto-fix: true]
@@ -78,7 +73,7 @@ linters:
     - gochecknoinits # Checks that no init functions are present in Go code [fast: true, auto-fix: false]
     - gocognit # Computes and checks the cognitive complexity of functions [fast: true, auto-fix: false]
     - godox # Tool for detection of FIXME, TODO and other comment keywords [fast: true, auto-fix: false]
-    - goerr113 # Golang linter to check the errors handling expressions [fast: false, auto-fix: false]
+    - err113 # Golang linter to check the errors handling expressions [fast: false, auto-fix: false]
     - gomnd # An analyzer to detect magic numbers. [fast: true, auto-fix: false]
     - lll # Reports long lines [fast: true, auto-fix: false]
     - maintidx # maintidx measures the maintainability index of each function. [fast: true, auto-fix: false]

--- a/internal/provider/edgegw/edgegateway_resource.go
+++ b/internal/provider/edgegw/edgegateway_resource.go
@@ -18,6 +18,7 @@ import (
 	v1 "github.com/orange-cloudavenue/cloudavenue-sdk-go/v1"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/client"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/metrics"
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/cloudavenue"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/pkg/uuid"
 )
@@ -391,7 +392,7 @@ func (r *edgeGatewayResource) Update(ctx context.Context, req resource.UpdateReq
 	ctx, cancel = context.WithTimeout(ctx, updateTimeout)
 	defer cancel()
 
-	edgegw, err := r.client.CAVSDK.V1.EdgeGateway.GetByID(plan.ID.Get())
+	edgegw, err := r.client.CAVSDK.V1.EdgeGateway.GetByID(common.ExtractUUID(plan.ID.Get()))
 	if err != nil {
 		resp.Diagnostics.AddError("Error retrieving edge gateway", err.Error())
 		return
@@ -443,7 +444,7 @@ func (r *edgeGatewayResource) Delete(ctx context.Context, req resource.DeleteReq
 		return
 	}
 
-	edgegw, err := r.client.CAVSDK.V1.EdgeGateway.GetByID(state.ID.Get())
+	edgegw, err := r.client.CAVSDK.V1.EdgeGateway.GetByID(common.ExtractUUID(state.ID.Get()))
 	if err != nil {
 		if commoncloudavenue.IsNotFound(err) {
 			resp.State.RemoveResource(ctx)
@@ -483,7 +484,7 @@ func (r *edgeGatewayResource) read(_ context.Context, planOrState *edgeGatewayRe
 
 	switch {
 	case planOrState.ID.IsKnown():
-		edgegw, err = r.client.CAVSDK.V1.EdgeGateway.GetByID(planOrState.ID.Get())
+		edgegw, err = r.client.CAVSDK.V1.EdgeGateway.GetByID(common.ExtractUUID(planOrState.ID.Get()))
 		if err != nil {
 			if commoncloudavenue.IsNotFound(err) {
 				return nil, false, nil


### PR DESCRIPTION

### Description of your changes

Now the edgegateway use UUID instead the URN for requesting the API. 

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
==============================================================================
--- PASS: TestAccEdgeGatewayResource (585.31s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  585.847s
```