### PR TITLE
fix: known after apply on the attribute `id` in `cloudavenue_vdc`

### DIFF
--- a/.changelog/755.txt
+++ b/.changelog/755.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_vdc` - Fix an issue with the VDC resource generate `Know after apply` on the attribute `id` if another attribute is changed.
+```

--- a/internal/provider/vdc/vdc_schema.go
+++ b/internal/provider/vdc/vdc_schema.go
@@ -50,6 +50,9 @@ func vdcSchema() superschema.Schema {
 				Common: &schemaR.StringAttribute{
 					MarkdownDescription: "The ID of the vDC.",
 					Computed:            true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 			},
 			"name": superschema.SuperStringAttribute{


### PR DESCRIPTION

### Description of your changes

Fix an issue with the VDC resource generate `Know after apply` on the attribute `id` if another attribute is changed.

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
--- PASS: TestAccVDCResource (359.04s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  360.128s
```