### PR TITLE
fix: failed to add more 1 org_network into a VApp

### DIFF
--- a/.changelog/810.txt
+++ b/.changelog/810.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_vapp_org_network` - Fix issue where only one org network was being added to the vApp.
+```

--- a/internal/provider/vapp/common_org_network.go
+++ b/internal/provider/vapp/common_org_network.go
@@ -30,7 +30,7 @@ func (s *orgNetworkModel) findOrgNetwork(vAppNetworkConfig *govcdtypes.NetworkCo
 			}
 			networkConfig.ID = id
 		} else if networkConfig.ID == "" && networkConfig.Link == nil {
-			break
+			continue
 		}
 
 		if (networkConfig.ID == s.ID.ValueString() && !s.ID.IsNull()) || (networkConfig.NetworkName == s.NetworkName.ValueString() && !s.NetworkName.IsNull()) {
@@ -38,6 +38,6 @@ func (s *orgNetworkModel) findOrgNetwork(vAppNetworkConfig *govcdtypes.NetworkCo
 		}
 	}
 
-	diags.AddError("Unable to find network ID or Name", "networkConfig.NetworkName or networkConfig.NetworkID is unknow")
+	diags.AddError("Unable to find network in the VApp", "The network was not found in the VApp")
 	return nil, nil, diags
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
--- PASS: TestAccOrgNetworkResource (509.56s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  510.234s
```