### PR TITLE
refactor: resource/datasource `cloudavenue_vapp_isolated_network`

### DIFF
--- a/.changelog/812.txt
+++ b/.changelog/812.txt
@@ -1,0 +1,11 @@
+```release-note:bug
+`resource/cloudavenue_vapp_org_network` - Fixed issue if `vapp_id` is provided the API return not found error.
+```
+
+```release-note:enhancement
+`resource/cloudavenue_vapp_org_network` - Minor improvements in documentation.
+```
+
+```release-note:enhancement
+`datasource/cloudavenue_vapp_org_network` - Minor improvements in documentation.
+```

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,6 @@ repos:
   rev: v4.6.0
   hooks:
     - id: check-merge-conflict
-    - id: trailing-whitespace
-      exclude: >
-        (?x)^(
-        docs/|
-        templates/|
-        )$
-    - id: end-of-file-fixer
     - id: forbid-submodules
 
 ## GOLANG

--- a/docs/data-sources/vapp_isolated_network.md
+++ b/docs/data-sources/vapp_isolated_network.md
@@ -67,10 +67,10 @@ output "dns" {
 - `dns2` (String) The secondary DNS server IP address for the network.
 - `dns_suffix` (String) The DNS suffix for the network.
 - `gateway` (String) The gateway IP address for the network. This value define also the network IP range with the prefix length.
-- `guest_vlan_allowed` (Boolean) Return True if Network allows guest VLAN.
-- `id` (String) The ID of the network.
+- `guest_vlan_allowed` (Boolean) True if Network allows guest VLAN.
+- `id` (String) The ID of the isolated network.
 - `netmask` (String) The netmask of the network.
-- `retain_ip_mac_enabled` (Boolean) Return network resources such as IP/MAC of router will be retained across deployments.
+- `retain_ip_mac_enabled` (Boolean) Specifies whether the network resources such as IP/MAC of router will be retained across deployments.
 - `static_ip_pool` (Attributes Set) A set of static IP pools to be used for this network. (see [below for nested schema](#nestedatt--static_ip_pool))
 
 <a id="nestedatt--static_ip_pool"></a>

--- a/docs/resources/vapp_isolated_network.md
+++ b/docs/resources/vapp_isolated_network.md
@@ -28,14 +28,16 @@ resource "cloudavenue_vapp_isolated_network" "example" {
   guest_vlan_allowed    = true
   retain_ip_mac_enabled = true
 
-  static_ip_pool = [{
-    start_address = "192.168.10.51"
-    end_address   = "192.168.10.101"
+  static_ip_pool = [
+    {
+      start_address = "192.168.10.51"
+      end_address   = "192.168.10.101"
     },
     {
       start_address = "192.168.10.10"
       end_address   = "192.168.10.30"
-  }]
+    }
+  ]
 }
 ```
 
@@ -53,9 +55,9 @@ resource "cloudavenue_vapp_isolated_network" "example" {
 - `dns1` (String) The primary DNS server IP address for the network. Must be a valid IP with net.ParseIP.
 - `dns2` (String) The secondary DNS server IP address for the network. Must be a valid IP with net.ParseIP.
 - `dns_suffix` (String) The DNS suffix for the network.
-- `guest_vlan_allowed` (Boolean) True if Network allows guest VLAN. Default to `false`.
+- `guest_vlan_allowed` (Boolean) True if Network allows guest VLAN. Value defaults to `false`.
 - `netmask` (String) (ForceNew) The netmask of the network. Must be a valid netmask. Value defaults to `255.255.255.0`.
-- `retain_ip_mac_enabled` (Boolean) Specifies whether the network resources such as IP/MAC of router will be retained across deployments. Default to `false`.
+- `retain_ip_mac_enabled` (Boolean) Specifies whether the network resources such as IP/MAC of router will be retained across deployments. Value defaults to `false`.
 - `static_ip_pool` (Attributes Set) A set of static IP pools to be used for this network. Set must contain at least 1 elements. (see [below for nested schema](#nestedatt--static_ip_pool))
 - `vapp_id` (String) (ForceNew) ID of the vApp. Ensure that one and only one attribute from this collection is set : `vapp_name`, `vapp_id`.
 - `vapp_name` (String) (ForceNew) Name of the vApp. Ensure that one and only one attribute from this collection is set : `vapp_id`, `vapp_name`.
@@ -63,7 +65,7 @@ resource "cloudavenue_vapp_isolated_network" "example" {
 
 ### Read-Only
 
-- `id` (String) The ID of the network.
+- `id` (String) The ID of the isolated network.
 
 <a id="nestedatt--static_ip_pool"></a>
 ### Nested Schema for `static_ip_pool`

--- a/docs/resources/vapp_org_network.md
+++ b/docs/resources/vapp_org_network.md
@@ -81,8 +81,8 @@ resource "cloudavenue_vapp_org_network" "example" {
 Import is supported using the following syntax:
 ```shell
 # if vdc is not specified, the default vdc will be used
-terraform import cloudavenue_vm_disk.example vapp_name.network_name
+terraform import cloudavenue_vapp_org_network.example vapp_name.network_name
 
 # if vdc is specified, the vdc will be used
-terraform import cloudavenue_vm_disk.example vdc.vapp_name.network_name
+terraform import cloudavenue_vapp_org_network.example vdc.vapp_name.network_name
 ```

--- a/examples/resources/cloudavenue_vapp_isolated_network/resource.tf
+++ b/examples/resources/cloudavenue_vapp_isolated_network/resource.tf
@@ -14,12 +14,14 @@ resource "cloudavenue_vapp_isolated_network" "example" {
   guest_vlan_allowed    = true
   retain_ip_mac_enabled = true
 
-  static_ip_pool = [{
-    start_address = "192.168.10.51"
-    end_address   = "192.168.10.101"
+  static_ip_pool = [
+    {
+      start_address = "192.168.10.51"
+      end_address   = "192.168.10.101"
     },
     {
       start_address = "192.168.10.10"
       end_address   = "192.168.10.30"
-  }]
+    }
+  ]
 }

--- a/examples/resources/cloudavenue_vapp_org_network/import.sh
+++ b/examples/resources/cloudavenue_vapp_org_network/import.sh
@@ -1,5 +1,5 @@
 # if vdc is not specified, the default vdc will be used
-terraform import cloudavenue_vm_disk.example vapp_name.network_name
+terraform import cloudavenue_vapp_org_network.example vapp_name.network_name
 
 # if vdc is specified, the vdc will be used
-terraform import cloudavenue_vm_disk.example vdc.vapp_name.network_name
+terraform import cloudavenue_vapp_org_network.example vdc.vapp_name.network_name

--- a/internal/provider/vapp/isolated_network_datasource.go
+++ b/internal/provider/vapp/isolated_network_datasource.go
@@ -5,22 +5,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/vmware/go-vcloud-director/v2/govcd"
-	govcdtypes "github.com/vmware/go-vcloud-director/v2/types/v56"
-
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/client"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/metrics"
-	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/network"
-	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/org"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/vapp"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/vdc"
-	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/pkg/utils"
-	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/pkg/uuid"
 )
 
 var (
@@ -34,25 +26,18 @@ func NewIsolatedNetworkDataSource() datasource.DataSource {
 
 type isolatedNetworkDataSource struct {
 	client *client.CloudAvenue
-
-	org  org.Org
-	vdc  vdc.VDC
-	vapp vapp.VAPP
+	vdc    vdc.VDC
+	vapp   vapp.VAPP
 }
 
 // Init Initializes the data source.
-func (d *isolatedNetworkDataSource) Init(ctx context.Context, dm *isolatedNetworkDataSourceModel) (diags diag.Diagnostics) {
-	d.org, diags = org.Init(d.client)
+func (d *isolatedNetworkDataSource) Init(ctx context.Context, dm *isolatedNetworkModel) (diags diag.Diagnostics) {
+	d.vdc, diags = vdc.Init(d.client, dm.VDC.StringValue)
 	if diags.HasError() {
 		return
 	}
 
-	d.vdc, diags = vdc.Init(d.client, dm.VDC)
-	if diags.HasError() {
-		return
-	}
-
-	d.vapp, diags = vapp.Init(d.client, d.vdc, dm.VAppID, dm.VAppName)
+	d.vapp, diags = vapp.Init(d.client, d.vdc, dm.VAppID.StringValue, dm.VAppName.StringValue)
 
 	return
 }
@@ -62,7 +47,7 @@ func (d *isolatedNetworkDataSource) Metadata(ctx context.Context, req datasource
 }
 
 func (d *isolatedNetworkDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema = network.GetSchema(network.SetIsolatedVapp()).GetDataSource(ctx)
+	resp.Schema = isolatedNetworkSchema().GetDataSource(ctx)
 }
 
 func (d *isolatedNetworkDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
@@ -87,12 +72,7 @@ func (d *isolatedNetworkDataSource) Configure(ctx context.Context, req datasourc
 
 func (d *isolatedNetworkDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	defer metrics.New("data.cloudavenue_vapp_isolated_network", d.client.GetOrgName(), metrics.Read)()
-
-	var (
-		config      = &isolatedNetworkDataSourceModel{}
-		diag        diag.Diagnostics
-		vAppNetwork = govcdtypes.VAppNetworkConfiguration{}
-	)
+	config := &isolatedNetworkModel{}
 
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, config)...)
@@ -100,83 +80,25 @@ func (d *isolatedNetworkDataSource) Read(ctx context.Context, req datasource.Rea
 		return
 	}
 
-	// Init the resource
+	// Init datasource
 	resp.Diagnostics.Append(d.Init(ctx, config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Get vApp Network information
-	vAppNetworkConfig, err := d.vapp.GetNetworkConfig()
-	if err != nil {
-		resp.Diagnostics.AddError("Error retrieving vApp network config", err.Error())
-		return
+	s := &isolatedNetworkResource{
+		client: d.client,
+		vdc:    d.vdc,
+		vapp:   d.vapp,
 	}
 
-	for _, networkConfig := range vAppNetworkConfig.NetworkConfig {
-		if networkConfig.NetworkName == config.Name.ValueString() {
-			vAppNetwork = networkConfig
-		}
-	}
-
-	if vAppNetwork == (govcdtypes.VAppNetworkConfiguration{}) {
-		resp.State.RemoveResource(ctx)
-		return
-	}
-
-	// Get UUID.
-	networkID, err := govcd.GetUuidFromHref(vAppNetwork.Link.HREF, false)
-	if err != nil {
-		resp.Diagnostics.AddError("Error on getting vApp network ID", err.Error())
-		return
-	}
-
-	plan := &isolatedNetworkDataSourceModel{
-		ID:                 utils.StringValueOrNull(uuid.Normalize(uuid.Network, networkID).String()),
-		VDC:                utils.StringValueOrNull(d.vdc.GetName()),
-		Name:               utils.StringValueOrNull(vAppNetwork.NetworkName),
-		Description:        utils.StringValueOrNull(vAppNetwork.Description),
-		VAppName:           utils.StringValueOrNull(config.VAppName.ValueString()),
-		VAppID:             utils.StringValueOrNull(config.VAppID.ValueString()),
-		Netmask:            types.StringNull(),
-		Gateway:            types.StringNull(),
-		DNS1:               types.StringNull(),
-		DNS2:               types.StringNull(),
-		DNSSuffix:          types.StringNull(),
-		GuestVLANAllowed:   types.BoolValue(*vAppNetwork.Configuration.GuestVlanAllowed),
-		RetainIPMacEnabled: types.BoolValue(*vAppNetwork.Configuration.RetainNetInfoAcrossDeployments),
-	}
-
-	// Get IP Scopes
-	if len(vAppNetwork.Configuration.IPScopes.IPScope) > 0 {
-		plan.Netmask = utils.StringValueOrNull(vAppNetwork.Configuration.IPScopes.IPScope[0].Netmask)
-		plan.Gateway = utils.StringValueOrNull(vAppNetwork.Configuration.IPScopes.IPScope[0].Gateway)
-		plan.DNS1 = utils.StringValueOrNull(vAppNetwork.Configuration.IPScopes.IPScope[0].DNS1)
-		plan.DNS2 = utils.StringValueOrNull(vAppNetwork.Configuration.IPScopes.IPScope[0].DNS2)
-		plan.DNSSuffix = utils.StringValueOrNull(vAppNetwork.Configuration.IPScopes.IPScope[0].DNSSuffix)
-	}
-
-	// Loop on static_ip_pool if it is not nil
-	staticIPRanges := make([]staticIPPoolModel, 0)
-	plan.StaticIPPool = types.SetNull(types.ObjectType{AttrTypes: staticIPPoolModelAttrTypes})
-	if vAppNetwork.Configuration.IPScopes.IPScope[0].IPRanges != nil {
-		for _, staticIPRange := range vAppNetwork.Configuration.IPScopes.IPScope[0].IPRanges.IPRange {
-			staticIPRanges = append(staticIPRanges, staticIPPoolModel{
-				StartAddress: utils.StringValueOrNull(staticIPRange.StartAddress),
-				EndAddress:   utils.StringValueOrNull(staticIPRange.EndAddress),
-			})
-		}
-
-		plan.StaticIPPool, diag = types.SetValueFrom(ctx, types.ObjectType{AttrTypes: staticIPPoolModelAttrTypes}, staticIPRanges)
-		resp.Diagnostics.Append(diag...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-	}
-
-	// Set refreshed state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	// Read data
+	data, _, diags := s.read(ctx, config)
+	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Set refreshed state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider/vapp/isolated_network_schema.go
+++ b/internal/provider/vapp/isolated_network_schema.go
@@ -1,37 +1,222 @@
 package vapp
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
+	schemaD "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	schemaR "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 
-	fboolplanmodifier "github.com/FrangipaneTeam/terraform-plugin-framework-planmodifiers/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 
-	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/vapp"
+	superschema "github.com/FrangipaneTeam/terraform-plugin-framework-superschema"
+	fstringvalidator "github.com/FrangipaneTeam/terraform-plugin-framework-validators/stringvalidator"
+
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/vdc"
 )
 
-func isolatedNetworkSchema() schema.Schema {
-	return schema.Schema{
-		MarkdownDescription: "Provides capability to attach an existing Org VDC Network to a vApp and toggle network features.",
-		Attributes: map[string]schema.Attribute{
-			"vdc":       vdc.Schema(),
-			"vapp_id":   vapp.Schema()["vapp_id"],
-			"vapp_name": vapp.Schema()["vapp_name"],
-			"guest_vlan_allowed": schema.BoolAttribute{
-				MarkdownDescription: "True if Network allows guest VLAN. Default to `false`.",
-				Optional:            true,
-				Computed:            true,
-				PlanModifiers: []planmodifier.Bool{
-					fboolplanmodifier.SetDefault(false),
+func isolatedNetworkSchema() superschema.Schema {
+	return superschema.Schema{
+		Resource: superschema.SchemaDetails{
+			MarkdownDescription: "Provides capability to attach an existing Org VDC Network to a vApp and toggle network features.",
+		},
+		DataSource: superschema.SchemaDetails{
+			MarkdownDescription: "Provides a Cloud Avenue isolated vAPP Network data source to read data or reference existing network.",
+		},
+		Attributes: superschema.Attributes{
+			"id": superschema.SuperStringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "The ID of the isolated network.",
+					Computed:            true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 			},
-			"retain_ip_mac_enabled": schema.BoolAttribute{
-				MarkdownDescription: "Specifies whether the network resources such as IP/MAC of router will be retained across deployments. Default to `false`.",
-				Optional:            true,
-				Computed:            true,
-				PlanModifiers: []planmodifier.Bool{
-					fboolplanmodifier.SetDefault(false),
+			"name": superschema.SuperStringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "The name of the network. This value must be unique within the `VDC` or `VDC Group` that owns the network.",
+					Required:            true,
+				},
+			},
+			"description": superschema.SuperStringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "A description of the network.",
+				},
+				Resource: &schemaR.StringAttribute{
+					Optional: true,
+				},
+				DataSource: &schemaD.StringAttribute{
+					Computed: true,
+				},
+			},
+			"gateway": superschema.SuperStringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "The gateway IP address for the network. This value define also the network IP range with the prefix length.",
+				},
+				Resource: &schemaR.StringAttribute{
+					Required: true,
+					Validators: []validator.String{
+						fstringvalidator.IsIP(),
+					},
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+				},
+				DataSource: &schemaD.StringAttribute{
+					Computed: true,
+				},
+			},
+			"netmask": superschema.SuperStringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "The netmask of the network.",
+					Computed:            true,
+				},
+				Resource: &schemaR.StringAttribute{
+					Optional: true,
+					Default:  stringdefault.StaticString("255.255.255.0"),
+					Validators: []validator.String{
+						fstringvalidator.IsNetmask(),
+					},
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+				},
+			},
+			"dns1": superschema.SuperStringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "The primary DNS server IP address for the network.",
+				},
+				Resource: &schemaR.StringAttribute{
+					Optional: true,
+					Validators: []validator.String{
+						fstringvalidator.IsIP(),
+					},
+				},
+				DataSource: &schemaD.StringAttribute{
+					Computed: true,
+				},
+			},
+			"dns2": superschema.SuperStringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "The secondary DNS server IP address for the network.",
+				},
+				Resource: &schemaR.StringAttribute{
+					Optional: true,
+					Validators: []validator.String{
+						fstringvalidator.IsIP(),
+					},
+				},
+				DataSource: &schemaD.StringAttribute{
+					Computed: true,
+				},
+			},
+			"dns_suffix": superschema.SuperStringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "The DNS suffix for the network.",
+				},
+				Resource: &schemaR.StringAttribute{
+					Optional: true,
+				},
+				DataSource: &schemaD.StringAttribute{
+					Computed: true,
+				},
+			},
+			"static_ip_pool": superschema.SuperSetNestedAttributeOf[isolatedNetworkModelStaticIPPool]{
+				Common: &schemaR.SetNestedAttribute{
+					MarkdownDescription: "A set of static IP pools to be used for this network.",
+				},
+				Resource: &schemaR.SetNestedAttribute{
+					Optional: true,
+					Validators: []validator.Set{
+						setvalidator.SizeAtLeast(1),
+					},
+				},
+				DataSource: &schemaD.SetNestedAttribute{
+					Computed: true,
+				},
+				Attributes: map[string]superschema.Attribute{
+					"start_address": superschema.SuperStringAttribute{
+						Common: &schemaR.StringAttribute{
+							MarkdownDescription: "The start address of the IP pool. This value must be a valid IP address in the network IP range.",
+						},
+						Resource: &schemaR.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								fstringvalidator.IsIP(),
+							},
+						},
+						DataSource: &schemaD.StringAttribute{
+							Computed: true,
+						},
+					},
+					"end_address": superschema.SuperStringAttribute{
+						Common: &schemaR.StringAttribute{
+							MarkdownDescription: "The end address of the IP pool. This value must be a valid IP address in the network IP range.",
+						},
+						Resource: &schemaR.StringAttribute{
+							Required: true,
+							Validators: []validator.String{
+								fstringvalidator.IsIP(),
+							},
+						},
+						DataSource: &schemaD.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+			"vdc": vdc.SuperSchemaSuperType(),
+			"vapp_id": superschema.SuperStringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "ID of the vApp.",
+					Computed:            true,
+					Optional:            true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+					Validators: []validator.String{
+						stringvalidator.ExactlyOneOf(path.MatchRoot("vapp_name"), path.MatchRoot("vapp_id")),
+					},
+				},
+			},
+			"vapp_name": superschema.SuperStringAttribute{
+				Common: &schemaR.StringAttribute{
+					MarkdownDescription: "Name of the vApp.",
+					Computed:            true,
+					Optional:            true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+					Validators: []validator.String{
+						stringvalidator.ExactlyOneOf(path.MatchRoot("vapp_id"), path.MatchRoot("vapp_name")),
+					},
+				},
+			},
+			"guest_vlan_allowed": superschema.SuperBoolAttribute{
+				Common: &schemaR.BoolAttribute{
+					MarkdownDescription: "True if Network allows guest VLAN.",
+					Computed:            true,
+				},
+				Resource: &schemaR.BoolAttribute{
+					Optional: true,
+					Default:  booldefault.StaticBool(false),
+				},
+			},
+			"retain_ip_mac_enabled": superschema.SuperBoolAttribute{
+				Common: &schemaR.BoolAttribute{
+					MarkdownDescription: "Specifies whether the network resources such as IP/MAC of router will be retained across deployments.",
+					Computed:            true,
+				},
+				Resource: &schemaR.BoolAttribute{
+					Optional: true,
+					Default:  booldefault.StaticBool(false),
 				},
 			},
 		},

--- a/internal/provider/vapp/isolated_network_types.go
+++ b/internal/provider/vapp/isolated_network_types.go
@@ -1,50 +1,38 @@
 package vapp
 
 import (
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/types"
+	supertypes "github.com/FrangipaneTeam/terraform-plugin-framework-supertypes"
+
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/pkg/utils"
 )
 
-type isolatedNetworkDataSourceModel struct {
-	ID                 types.String `tfsdk:"id"`
-	VDC                types.String `tfsdk:"vdc"`
-	Name               types.String `tfsdk:"name"`
-	Description        types.String `tfsdk:"description"`
-	VAppName           types.String `tfsdk:"vapp_name"`
-	VAppID             types.String `tfsdk:"vapp_id"`
-	Netmask            types.String `tfsdk:"netmask"`
-	Gateway            types.String `tfsdk:"gateway"`
-	DNS1               types.String `tfsdk:"dns1"`
-	DNS2               types.String `tfsdk:"dns2"`
-	DNSSuffix          types.String `tfsdk:"dns_suffix"`
-	GuestVLANAllowed   types.Bool   `tfsdk:"guest_vlan_allowed"`
-	RetainIPMacEnabled types.Bool   `tfsdk:"retain_ip_mac_enabled"`
-	StaticIPPool       types.Set    `tfsdk:"static_ip_pool"`
-}
+type (
+	isolatedNetworkModel struct {
+		ID                 supertypes.StringValue                                              `tfsdk:"id"`
+		VDC                supertypes.StringValue                                              `tfsdk:"vdc"`
+		Name               supertypes.StringValue                                              `tfsdk:"name"`
+		Description        supertypes.StringValue                                              `tfsdk:"description"`
+		VAppName           supertypes.StringValue                                              `tfsdk:"vapp_name"`
+		VAppID             supertypes.StringValue                                              `tfsdk:"vapp_id"`
+		Netmask            supertypes.StringValue                                              `tfsdk:"netmask"`
+		Gateway            supertypes.StringValue                                              `tfsdk:"gateway"`
+		DNS1               supertypes.StringValue                                              `tfsdk:"dns1"`
+		DNS2               supertypes.StringValue                                              `tfsdk:"dns2"`
+		DNSSuffix          supertypes.StringValue                                              `tfsdk:"dns_suffix"`
+		GuestVLANAllowed   supertypes.BoolValue                                                `tfsdk:"guest_vlan_allowed"`
+		RetainIPMacEnabled supertypes.BoolValue                                                `tfsdk:"retain_ip_mac_enabled"`
+		StaticIPPool       supertypes.SetNestedObjectValueOf[isolatedNetworkModelStaticIPPool] `tfsdk:"static_ip_pool"`
+	}
 
-type isolatedNetworkResourceModel struct {
-	ID                 types.String `tfsdk:"id"`
-	VDC                types.String `tfsdk:"vdc"`
-	Name               types.String `tfsdk:"name"`
-	Description        types.String `tfsdk:"description"`
-	VAppName           types.String `tfsdk:"vapp_name"`
-	VAppID             types.String `tfsdk:"vapp_id"`
-	Netmask            types.String `tfsdk:"netmask"`
-	Gateway            types.String `tfsdk:"gateway"`
-	DNS1               types.String `tfsdk:"dns1"`
-	DNS2               types.String `tfsdk:"dns2"`
-	DNSSuffix          types.String `tfsdk:"dns_suffix"`
-	GuestVLANAllowed   types.Bool   `tfsdk:"guest_vlan_allowed"`
-	RetainIPMacEnabled types.Bool   `tfsdk:"retain_ip_mac_enabled"`
-	StaticIPPool       types.Set    `tfsdk:"static_ip_pool"`
-}
+	isolatedNetworkModelStaticIPPool struct {
+		StartAddress supertypes.StringValue `tfsdk:"start_address"`
+		EndAddress   supertypes.StringValue `tfsdk:"end_address"`
+	}
+)
 
-type staticIPPoolModel struct {
-	StartAddress types.String `tfsdk:"start_address"`
-	EndAddress   types.String `tfsdk:"end_address"`
-}
-
-var staticIPPoolModelAttrTypes = map[string]attr.Type{
-	"start_address": types.StringType,
-	"end_address":   types.StringType,
+// Copy returns a copy of the backupModel.
+func (rm *isolatedNetworkModel) Copy() *isolatedNetworkModel {
+	x := &isolatedNetworkModel{}
+	utils.ModelCopy(rm, x)
+	return x
 }

--- a/internal/testsacc/acctest_datasources_test.go
+++ b/internal/testsacc/acctest_datasources_test.go
@@ -44,5 +44,9 @@ func GetDataSourceConfig() map[testsacc.ResourceName]func() *testsacc.ResourceCo
 		// * IAM
 		IAMRolesDataSourceName: testsacc.NewResourceConfig(NewIAMRolesDataSourceTest()),
 		IAMUserDataSourceName:  testsacc.NewResourceConfig(NewIAMUserDataSourceTest()),
+
+		// * VApp
+		VAppDatasourceName:                testsacc.NewResourceConfig(NewVAppDatasourceTest()),
+		VAppIsolatedNetworkDataSourceName: testsacc.NewResourceConfig(NewVAppIsolatedNetworkDataSourceTest()),
 	}
 }

--- a/internal/testsacc/acctest_resources_test.go
+++ b/internal/testsacc/acctest_resources_test.go
@@ -14,8 +14,9 @@ func GetResourceConfig() map[testsacc.ResourceName]func() *testsacc.ResourceConf
 		VDCGroupResourceName: testsacc.NewResourceConfig(NewVDCGroupResourceTest()),
 
 		// * VAPP
-		VAppResourceName:           testsacc.NewResourceConfig(NewVAppResourceTest()),
-		VAppOrgNetworkResourceName: testsacc.NewResourceConfig(NewVAppOrgNetworkResourceTest()),
+		VAppResourceName:                testsacc.NewResourceConfig(NewVAppResourceTest()),
+		VAppOrgNetworkResourceName:      testsacc.NewResourceConfig(NewVAppOrgNetworkResourceTest()),
+		VAppIsolatedNetworkResourceName: testsacc.NewResourceConfig(NewVAppIsolatedNetworkResourceTest()),
 
 		// * Network
 		NetworkRoutedResourceName: testsacc.NewResourceConfig(NewNetworkRoutedResourceTest()),

--- a/internal/testsacc/vapp_datasource_test.go
+++ b/internal/testsacc/vapp_datasource_test.go
@@ -12,7 +12,7 @@ import (
 var _ testsacc.TestACC = &VAppDatasource{}
 
 const (
-	VAppDatasourceName = testsacc.ResourceName("data.cloudavenue_s3_bucket")
+	VAppDatasourceName = testsacc.ResourceName("data.cloudavenue_vapp")
 )
 
 type VAppDatasource struct{}


### PR DESCRIPTION
### Description of your changes


If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
--- PASS: TestAccVAppIsolatedNetworkResource (99.10s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  99.783s

--- PASS: TestAccVAppIsolatedNetworkDataSource (94.65s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  95.178s
```