### PR TITLE
fix: bug vapp network not created

### DIFF
--- a/.changelog/817.txt
+++ b/.changelog/817.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_vm` - Now the VApp data has refreshed before the creation of the VM.
+```

--- a/internal/provider/vm/vm_resource.go
+++ b/internal/provider/vm/vm_resource.go
@@ -171,6 +171,15 @@ func (r *vmResource) Create(ctx context.Context, req resource.CreateRequest, res
 
 	defer r.vapp.UnlockVAPP(ctx)
 
+	// * Refresh VApp
+	if err := r.vapp.Refresh(); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to refresh VApp",
+			fmt.Sprintf("Error: %s", err),
+		)
+		return
+	}
+
 	// * Create VM with Template
 	if !deployOS.VappTemplateID.IsNull() {
 		vmCreated, d = r.createVMWithTemplate(ctx, *plan)


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested
```
=== RUN   TestAccOrgNetworkResource
2024/11/12 15:25:03 Starting building dependencies config
2024/11/12 15:25:03 Adding dependency cloudavenue_vdc.example
2024/11/12 15:25:03 Adding dependency cloudavenue_vapp.example
2024/11/12 15:25:03 Dependency cloudavenue_vdc.example already exists
2024/11/12 15:25:03 Adding dependency cloudavenue_network_routed.example
2024/11/12 15:25:03 Adding dependency data.cloudavenue_tier0_vrf.example
2024/11/12 15:25:03 Adding dependency cloudavenue_edgegateway.example
2024/11/12 15:25:03 Finished building dependencies config. Found 5 dependencies
2024/11/12 15:25:03 
                                        resource "cloudavenue_vapp_org_network" "example" {
                                                vapp_name    = cloudavenue_vapp.example.name
                                                network_name = cloudavenue_network_routed.example.name
                                                vdc          = cloudavenue_vdc.example.name
                                          }


                                        resource "cloudavenue_vdc" "example" {
                                                name                  = "tftest-lglmvsumtofszlyn"
                                                description           = "tftest-Pax poterunt."
                                                cpu_allocated         = 22000
                                                memory_allocated      = 30
                                                cpu_speed_in_mhz      = 2200
                                                billing_model         = "PAYG"
                                                disponibility_class   = "ONE-ROOM"
                                                service_class         = "STD"
                                                storage_billing_model = "PAYG"
                                          
                                                storage_profiles = [{
                                                  class   = "gold"
                                                  default = true
                                                  limit   = 500
                                                }]
                                          
                                        }

                                        resource "cloudavenue_vapp" "example" {
                                                name        = "tftest-euwrqszzbypygbbd"
                                                description = "tftest-xqouwdijjzwdmryj"
                                                vdc             = cloudavenue_vdc.example.name
                                        }

                                        resource "cloudavenue_network_routed" "example" {
                                                name        = "tftest-lamotawgecruuxxo"
                                                description = "tftest-unvppjvfptdzqper"
                                          
                                                edge_gateway_id = cloudavenue_edgegateway.example.id
                                          
                                                gateway       = "192.168.1.254"
                                                prefix_length = 24
                                          
                                                dns1 = "1.1.1.1"
                                                dns2 = "8.8.8.8"
                                          
                                                dns_suffix = "example"
                                          
                                                static_ip_pool = [
                                                  {
                                                        start_address = "192.168.1.10"
                                                        end_address   = "192.168.1.20"
                                                  }
                                                ]
                                        }

                                        data "cloudavenue_tier0_vrf" "example" {
                                                name = "prvrf01eocb0006205allsp01"
                                        }

                                        resource "cloudavenue_edgegateway" "example" {
                                                owner_name     = cloudavenue_vdc.example.name
                                                tier0_vrf_name = data.cloudavenue_tier0_vrf.example.name
                                                owner_type     = "vdc"
                                        }
--- PASS: TestAccOrgNetworkResource (314.60s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  315.086s
```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->