### PR TITLE
chore: add testsacc ress `iam_user_saml` and set to prod ready

### DIFF
--- a/docs/resources/iam_user_saml.md
+++ b/docs/resources/iam_user_saml.md
@@ -7,8 +7,6 @@ description: |-
 
 # cloudavenue_iam_user_saml (Resource)
 
-~> **Beta resource** Resources marked as beta are not yet ready for production use. They are provided for early access to new features and are subject to change.
-
 The `cloudavenue_iam_user_saml` resource allows you to import SAML users in Cloud Avenue.
 
 ## Example Usage

--- a/internal/provider/iam/user_saml_schema.go
+++ b/internal/provider/iam/user_saml_schema.go
@@ -36,7 +36,7 @@ func userSAMLSchema(_ context.Context) superschema.Schema {
 					},
 				},
 			},
-			"role_name": superschema.StringAttribute{
+			"role_name": superschema.SuperStringAttribute{
 				Common: &schemaR.StringAttribute{
 					MarkdownDescription: "The role assigned to the user.",
 				},
@@ -44,7 +44,7 @@ func userSAMLSchema(_ context.Context) superschema.Schema {
 					Required: true,
 				},
 			},
-			"enabled": superschema.BoolAttribute{
+			"enabled": superschema.SuperBoolAttribute{
 				Common: &schemaR.BoolAttribute{
 					MarkdownDescription: "`true` if the user is enabled and can log in.",
 				},
@@ -54,7 +54,7 @@ func userSAMLSchema(_ context.Context) superschema.Schema {
 					Default:  booldefault.StaticBool(true),
 				},
 			},
-			"deployed_vm_quota": superschema.Int64Attribute{
+			"deployed_vm_quota": superschema.SuperInt64Attribute{
 				Common: &schemaR.Int64Attribute{
 					MarkdownDescription: "Quota of vApps that this user can deploy. A value of `0` specifies an unlimited quota.",
 				},
@@ -64,7 +64,7 @@ func userSAMLSchema(_ context.Context) superschema.Schema {
 					Default:  int64default.StaticInt64(0),
 				},
 			},
-			"stored_vm_quota": superschema.Int64Attribute{
+			"stored_vm_quota": superschema.SuperInt64Attribute{
 				Common: &schemaR.Int64Attribute{
 					MarkdownDescription: "Quota of vApps that this user can store. A value of `0` specifies an unlimited quota.",
 				},
@@ -74,7 +74,7 @@ func userSAMLSchema(_ context.Context) superschema.Schema {
 					Default:  int64default.StaticInt64(0),
 				},
 			},
-			"take_ownership": superschema.BoolAttribute{
+			"take_ownership": superschema.SuperBoolAttribute{
 				Resource: &schemaR.BoolAttribute{
 					MarkdownDescription: "`true` if the user should take ownership of all vApps and media that are currently owned by the user that is being deleted.",
 					Optional:            true,

--- a/internal/testsacc/acctest_resources_test.go
+++ b/internal/testsacc/acctest_resources_test.go
@@ -53,6 +53,7 @@ func GetResourceConfig() map[testsacc.ResourceName]func() *testsacc.ResourceConf
 		PublicIPResourceName: testsacc.NewResourceConfig(NewPublicIPResourceTest()),
 
 		// * IAM
-		IAMUserResourceName: testsacc.NewResourceConfig(NewIAMUserResourceTest()),
+		IAMUserResourceName:     testsacc.NewResourceConfig(NewIAMUserResourceTest()),
+		IAMUserSAMLResourceName: testsacc.NewResourceConfig(NewIAMUserSAMLResourceTest()),
 	}
 }

--- a/internal/testsacc/iam_user_datasource_test.go
+++ b/internal/testsacc/iam_user_datasource_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/testsacc"
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/pkg/uuid"
 )
 
 var _ testsacc.TestACC = &IAMUserDataSource{}
@@ -42,24 +43,31 @@ func (r *IAMUserDataSource) Tests(ctx context.Context) map[testsacc.TestName]fun
 				Create: testsacc.TFConfig{
 					TFConfig: `
 					data "cloudavenue_iam_user" "example" {
-							name = cloudavenue_iam_user.example.name
+						name = cloudavenue_iam_user.example.name
 					}`,
 					Checks: GetResourceConfig()[IAMUserResourceName]().GetDefaultChecks(),
 				},
 			}
 		},
-		"example_saml_user": func(_ context.Context, _ string) testsacc.Test {
+		"example_saml_user": func(_ context.Context, resourceName string) testsacc.Test {
 			return testsacc.Test{
 				CommonDependencies: func() (resp testsacc.DependenciesConfigResponse) {
-					// resp.Append(GetResourceConfig()[IAMUserSAMLResourceName]().GetDefaultConfig)
+					resp.Append(GetResourceConfig()[IAMUserSAMLResourceName]().GetDefaultConfig)
 					return
 				},
 				Create: testsacc.TFConfig{
 					TFConfig: `
 					data "cloudavenue_iam_user" "example_saml_user" {
-							name = cloudavenue_iam_user_saml.example.user_name
+						name = cloudavenue_iam_user_saml.example.user_name
 					}`,
-					Checks: GetResourceConfig()[IAMUserResourceName]().GetDefaultChecks(),
+					Checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttrWith(resourceName, "id", uuid.TestIsType(uuid.User)),
+						resource.TestCheckResourceAttr(resourceName, "name", "mickael.stanislas.ext"),
+						resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+						resource.TestCheckResourceAttr(resourceName, "deployed_vm_quota", "0"),
+						resource.TestCheckResourceAttr(resourceName, "stored_vm_quota", "0"),
+						resource.TestCheckResourceAttr(resourceName, "role_name", "Organization Administrator"),
+					},
 				},
 			}
 		},

--- a/internal/testsacc/iam_user_datasource_test.go
+++ b/internal/testsacc/iam_user_datasource_test.go
@@ -27,7 +27,6 @@ func (r *IAMUserDataSource) GetResourceName() string {
 }
 
 func (r *IAMUserDataSource) DependenciesConfig() (resp testsacc.DependenciesConfigResponse) {
-	resp.Append(GetResourceConfig()[IAMUserResourceName]().GetDefaultConfig)
 	return
 }
 
@@ -36,10 +35,29 @@ func (r *IAMUserDataSource) Tests(ctx context.Context) map[testsacc.TestName]fun
 		// * Test One (example)
 		"example": func(_ context.Context, _ string) testsacc.Test {
 			return testsacc.Test{
+				CommonDependencies: func() (resp testsacc.DependenciesConfigResponse) {
+					resp.Append(GetResourceConfig()[IAMUserResourceName]().GetDefaultConfig)
+					return
+				},
 				Create: testsacc.TFConfig{
 					TFConfig: `
 					data "cloudavenue_iam_user" "example" {
 							name = cloudavenue_iam_user.example.name
+					}`,
+					Checks: GetResourceConfig()[IAMUserResourceName]().GetDefaultChecks(),
+				},
+			}
+		},
+		"example_saml_user": func(_ context.Context, _ string) testsacc.Test {
+			return testsacc.Test{
+				CommonDependencies: func() (resp testsacc.DependenciesConfigResponse) {
+					// resp.Append(GetResourceConfig()[IAMUserSAMLResourceName]().GetDefaultConfig)
+					return
+				},
+				Create: testsacc.TFConfig{
+					TFConfig: `
+					data "cloudavenue_iam_user" "example_saml_user" {
+							name = cloudavenue_iam_user_saml.example.user_name
 					}`,
 					Checks: GetResourceConfig()[IAMUserResourceName]().GetDefaultChecks(),
 				},

--- a/internal/testsacc/iam_user_saml_resource_test.go
+++ b/internal/testsacc/iam_user_saml_resource_test.go
@@ -10,28 +10,28 @@ import (
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/pkg/uuid"
 )
 
-var _ testsacc.TestACC = &iamUserSAMLResource{}
+var _ testsacc.TestACC = &IAMUserSAMLResource{}
 
 const (
-	iamUserSAMLResourceName = testsacc.ResourceName("cloudavenue_iam_user_saml")
+	IAMUserSAMLResourceName = testsacc.ResourceName("cloudavenue_iam_user_saml")
 )
 
-type iamUserSAMLResource struct{}
+type IAMUserSAMLResource struct{}
 
-func NewiamUserSAMLResourceTest() testsacc.TestACC {
-	return &iamUserSAMLResource{}
+func NewIAMUserSAMLResourceTest() testsacc.TestACC {
+	return &IAMUserSAMLResource{}
 }
 
 // GetResourceName returns the name of the resource.
-func (r *iamUserSAMLResource) GetResourceName() string {
-	return iamUserSAMLResourceName.String()
+func (r *IAMUserSAMLResource) GetResourceName() string {
+	return IAMUserSAMLResourceName.String()
 }
 
-func (r *iamUserSAMLResource) DependenciesConfig() (resp testsacc.DependenciesConfigResponse) {
+func (r *IAMUserSAMLResource) DependenciesConfig() (resp testsacc.DependenciesConfigResponse) {
 	return
 }
 
-func (r *iamUserSAMLResource) Tests(ctx context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
+func (r *IAMUserSAMLResource) Tests(ctx context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
 	return map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test{
 		"example": func(_ context.Context, resourceName string) testsacc.Test {
 			return testsacc.Test{
@@ -144,10 +144,10 @@ func (r *iamUserSAMLResource) Tests(ctx context.Context) map[testsacc.TestName]f
 	}
 }
 
-func TestAcciamUserSAMLResource(t *testing.T) {
+func TestAccIAMUserSAMLResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		Steps:                    testsacc.GenerateTests(&iamUserSAMLResource{}),
+		Steps:                    testsacc.GenerateTests(&IAMUserSAMLResource{}),
 	})
 }

--- a/templates/resources/iam_user_saml.md.tmpl
+++ b/templates/resources/iam_user_saml.md.tmpl
@@ -7,8 +7,6 @@ description: |-
 
 # {{.Name}} ({{.Type}})
 
-~> **Beta resource** Resources marked as beta are not yet ready for production use. They are provided for early access to new features and are subject to change.
-
 {{ .Description | trimspace }}
 
 {{ if .HasExample -}}


### PR DESCRIPTION
### Description of your changes

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
--- PASS: TestAcciamUserSAMLResource (44.36s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  44.866s

--- PASS: TestAccIAMUserDataSource (14.08s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  15.046s
```