### PR TITLE
fix: bad ID returned in datasource app_port_profile

### DIFF
--- a/.changelog/849.txt
+++ b/.changelog/849.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+`datasource/cloudavenue_edgegateway_app_port_profile` - Fixed the issue where the `cloudavenue_edgegateway_app_port_profile` datasource was not returning the correct value App Port Profile ID.
+```
+
+```release-note:breaking-change
+`datasource/cloudavenue_edgegateway_app_port_profile` - Now the datasource require one of the following attributes to be set: `edge_gateway_id` or `edge_gateway_name`.
+```

--- a/docs/data-sources/edgegateway_app_port_profile.md
+++ b/docs/data-sources/edgegateway_app_port_profile.md
@@ -25,6 +25,8 @@ data "cloudavenue_edgegateway_app_port_profile" "example" {
 
 ### Optional
 
+- `edge_gateway_id` (String) ID of the Edge Gateway. Ensure that one and only one attribute from this collection is set : `edge_gateway_id`, `edge_gateway_name`.
+- `edge_gateway_name` (String) Name of the Edge Gateway. Ensure that one and only one attribute from this collection is set : `edge_gateway_id`, `edge_gateway_name`.
 - `id` (String) The ID of the App Port profile. Ensure that one and only one attribute from this collection is set : `name`, `id`.
 - `name` (String) Application Port Profile name. Ensure that one and only one attribute from this collection is set : `name`, `id`.
 

--- a/internal/provider/edgegw/app_port_profile_schema.go
+++ b/internal/provider/edgegw/app_port_profile_schema.go
@@ -78,26 +78,30 @@ func appPortProfilesSchema(_ context.Context) superschema.Schema {
 				},
 			},
 			"edge_gateway_id": superschema.SuperStringAttribute{
-				Resource: &schemaR.StringAttribute{
+				Common: &schemaR.StringAttribute{
 					MarkdownDescription: "ID of the Edge Gateway.",
 					Optional:            true,
 					Computed:            true,
 					Validators: []validator.String{
 						stringvalidator.ExactlyOneOf(path.MatchRoot("edge_gateway_id"), path.MatchRoot("edge_gateway_name")),
 					},
+				},
+				Resource: &schemaR.StringAttribute{
 					PlanModifiers: []planmodifier.String{
 						stringplanmodifier.RequiresReplaceIfConfigured(),
 					},
 				},
 			},
 			"edge_gateway_name": superschema.SuperStringAttribute{
-				Resource: &schemaR.StringAttribute{
+				Common: &schemaR.StringAttribute{
 					MarkdownDescription: "Name of the Edge Gateway.",
 					Optional:            true,
 					Computed:            true,
 					Validators: []validator.String{
 						stringvalidator.ExactlyOneOf(path.MatchRoot("edge_gateway_id"), path.MatchRoot("edge_gateway_name")),
 					},
+				},
+				Resource: &schemaR.StringAttribute{
 					PlanModifiers: []planmodifier.String{
 						stringplanmodifier.RequiresReplaceIfConfigured(),
 					},

--- a/internal/provider/edgegw/app_port_profile_type.go
+++ b/internal/provider/edgegw/app_port_profile_type.go
@@ -21,13 +21,6 @@ type AppPortProfileModel struct {
 	AppPorts        supertypes.ListNestedObjectValueOf[AppPortProfileModelAppPort] `tfsdk:"app_ports"`
 }
 
-type AppPortProfileModelADatasource struct {
-	ID          supertypes.StringValue                                         `tfsdk:"id"`
-	Name        supertypes.StringValue                                         `tfsdk:"name"`
-	Description supertypes.StringValue                                         `tfsdk:"description"`
-	AppPorts    supertypes.ListNestedObjectValueOf[AppPortProfileModelAppPort] `tfsdk:"app_ports"`
-}
-
 type AppPortProfileModelAppPort struct {
 	Protocol supertypes.StringValue        `tfsdk:"protocol"`
 	Ports    supertypes.SetValueOf[string] `tfsdk:"ports"`


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
--- PASS: TestAccEdgeGatewayAppPortProfileResource (404.90s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  405.547s

--- PASS: TestAccEdgeGatewayAppPortProfileDataSource (1596.785s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  1596.785s
```
