### PR TITLE
test: use vdcg resource instead vdc_group

### DIFF
--- a/internal/testsacc/edgegw_edgegateway_resource_test.go
+++ b/internal/testsacc/edgegw_edgegateway_resource_test.go
@@ -156,14 +156,14 @@ func (r *EdgeGatewayResource) Tests(ctx context.Context) map[testsacc.TestName]f
 					resource.TestCheckResourceAttrSet(resourceName, "description"),
 				},
 				CommonDependencies: func() (resp testsacc.DependenciesConfigResponse) {
-					resp.Append(GetResourceConfig()[VDCGroupResourceName]().GetDefaultConfig)
+					resp.Append(GetResourceConfig()[VDCGResourceName]().GetDefaultConfig)
 					return
 				},
 				// ! Create testing
 				Create: testsacc.TFConfig{
 					TFConfig: testsacc.GenerateFromTemplate(resourceName, `
 					resource "cloudavenue_edgegateway" "example_with_vdc_group" {
-						owner_name     = cloudavenue_vdc_group.example.name
+						owner_name     = cloudavenue_vdcg.example.name
 						tier0_vrf_name = data.cloudavenue_tier0_vrf.example.name
 						owner_type     = "vdc-group"
 						bandwidth      = 25
@@ -175,7 +175,7 @@ func (r *EdgeGatewayResource) Tests(ctx context.Context) map[testsacc.TestName]f
 					{
 						TFConfig: testsacc.GenerateFromTemplate(resourceName, `
 						resource "cloudavenue_edgegateway" "example_with_vdc_group" {
-							owner_name     = cloudavenue_vdc_group.example.name
+							owner_name     = cloudavenue_vdcg.example.name
 							tier0_vrf_name = data.cloudavenue_tier0_vrf.example.name
 							owner_type     = "vdc-group"
 							bandwidth      = 5


### PR DESCRIPTION
<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [ ] Write or modify examples in `examples/` directory
- [ ] Write or modify acceptance tests
- [ ] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
--- PASS: TestAccEdgeGatewayResource (225.46s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  225.992s
```