### PR TITLE
chore: add movestate and deprecation notice

### DIFF
--- a/.changelog/888.txt
+++ b/.changelog/888.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/cloudavenue_network_isolated` - Add a migration guide to migrate from `cloudavenue_network_isolated` to `cloudavenue_vdc_network_isolated`.
+```

--- a/docs/resources/network_isolated.md
+++ b/docs/resources/network_isolated.md
@@ -12,31 +12,78 @@ Provides a Cloud Avenue VDC isolated Network. This can be used to create, modify
 
  !> **Resource deprecated** The resource has renamed to [`cloudavenue_vdc_network_isolated`](https://registry.terraform.io/providers/orange-cloudavenue/cloudavenue/latest/docs/resources/vdc_network_isolated), it will be removed in the version [`v0.32.0`](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/20) of the provider. See the [GitHub issue](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/880) for more information.
 
+
+## How to migrate existing resources
+
+Original configuration:
+
+```terraform
+resource "cloudavenue_network_isolated" "example" {
+  name = "my-isolated-network"
+  vdc  = cloudavenue_vdc.example.name
+
+  gateway       = "192.168.0.1"
+  prefix_length = 24
+
+  dns1       = "192.168.0.2"
+  dns2       = "192.168.0.3"
+  dns_suffix = "example.local"
+}
+```
+
+Migrated configuration:
+
+Rename the resource to `cloudavenue_vdc_network_isolated` and add the `moved` block to the configuration:
+
+```hcl
+resource "cloudavenue_vdc_network_isolated" "example" {
+  name = "my-isolated-network"
+  vdc  = cloudavenue_vdc.example.name
+
+  gateway       = "192.168.0.1"
+  prefix_length = 24
+
+  dns1       = "192.168.0.2"
+  dns2       = "192.168.0.3"
+  dns_suffix = "example.local"
+}
+
+moved {
+  from = cloudavenue_network_isolated.example
+  to   = cloudavenue_vdc_network_isolated.example
+}
+```
+
+Run `terraform plan` and `terraform apply` to migrate the resource.
+
+Example of terraform plan output:
+
+```shell
+Terraform will perform the following actions:
+
+  # cloudavenue_network_isolated.example has moved to cloudavenue_vdc_network_isolated.example
+    resource "cloudavenue_vdc_network_isolated" "example" {
+        id                 = "urn:vcloud:network:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        name               = "rsx-example-isolated-network"
+        # (9 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+```
+
 ## Example Usage
 
 ```terraform
 resource "cloudavenue_network_isolated" "example" {
-  vdc         = "VDC_Test"
-  name        = "rsx-example-isolated-network"
-  description = "My isolated Org VDC network"
+  name = "my-isolated-network"
+  vdc  = cloudavenue_vdc.example.name
 
-  gateway       = "1.1.1.1"
+  gateway       = "192.168.0.1"
   prefix_length = 24
 
-  dns1       = "8.8.8.8"
-  dns2       = "8.8.4.4"
-  dns_suffix = "example.com"
-
-  static_ip_pool = [
-    {
-      start_address = "1.1.1.10"
-      end_address   = "1.1.1.20"
-    },
-    {
-      start_address = "1.1.1.100"
-      end_address   = "1.1.1.103"
-    }
-  ]
+  dns1       = "192.168.0.2"
+  dns2       = "192.168.0.3"
+  dns_suffix = "example.local"
 }
 ```
 

--- a/examples/resources/cloudavenue_network_isolated/resource.tf
+++ b/examples/resources/cloudavenue_network_isolated/resource.tf
@@ -1,23 +1,11 @@
 resource "cloudavenue_network_isolated" "example" {
-  vdc         = "VDC_Test"
-  name        = "rsx-example-isolated-network"
-  description = "My isolated Org VDC network"
+  name = "my-isolated-network"
+  vdc  = cloudavenue_vdc.example.name
 
-  gateway       = "1.1.1.1"
+  gateway       = "192.168.0.1"
   prefix_length = 24
 
-  dns1       = "8.8.8.8"
-  dns2       = "8.8.4.4"
-  dns_suffix = "example.com"
-
-  static_ip_pool = [
-    {
-      start_address = "1.1.1.10"
-      end_address   = "1.1.1.20"
-    },
-    {
-      start_address = "1.1.1.100"
-      end_address   = "1.1.1.103"
-    }
-  ]
+  dns1       = "192.168.0.2"
+  dns2       = "192.168.0.3"
+  dns_suffix = "example.local"
 }

--- a/internal/provider/common/network/schema.go
+++ b/internal/provider/common/network/schema.go
@@ -299,7 +299,7 @@ func GetSchema(opts ...networkSchemaOpts) superschema.Schema {
 			Renamed:                           true,
 			TargetResourceName:                "cloudavenue_vdc_network_isolated",
 			TargetRelease:                     "v0.32.0",
-			LinkToMigrationGuide:              "https://registry.terraform.io/providers/orange-cloudavenue/cloudavenue/latest/docs/resources/vdc_group#how-to-migrate-existing-resources",
+			LinkToMigrationGuide:              "https://registry.terraform.io/providers/orange-cloudavenue/cloudavenue/latest/docs/resources/network_isolated#how-to-migrate-existing-resources",
 			LinkToNewResourceDoc:              "https://registry.terraform.io/providers/orange-cloudavenue/cloudavenue/latest/docs/resources/vdc_network_isolated",
 			LinkToMilestone:                   "https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/20",
 			LinkToIssue:                       "https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/880",

--- a/internal/provider/network/common_network.go
+++ b/internal/provider/network/common_network.go
@@ -1,13 +1,8 @@
 package network
 
 import (
-	"github.com/vmware/go-vcloud-director/v2/govcd"
-
 	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-
-	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/org"
 )
 
 type staticIPPool struct {
@@ -20,6 +15,9 @@ var staticIPPoolAttrTypes = map[string]attr.Type{
 	"end_address":   types.StringType,
 }
 
+// IsolatedModel is the structure used by vdc package for the migration of the resource.
+type IsolatedModel = networkIsolatedModel
+
 type networkIsolatedModel struct {
 	ID           types.String `tfsdk:"id"`
 	VDC          types.String `tfsdk:"vdc"`
@@ -31,32 +29,4 @@ type networkIsolatedModel struct {
 	DNS2         types.String `tfsdk:"dns2"`
 	DNSSuffix    types.String `tfsdk:"dns_suffix"`
 	StaticIPPool types.Set    `tfsdk:"static_ip_pool"`
-}
-
-// Get parent edge gateway ID.
-func GetParentEdgeGatewayID(org org.Org, edgeGatewayID string) (*string, diag.Diagnostic) {
-	anyEdgeGateway, err := org.GetAnyTypeEdgeGatewayById(edgeGatewayID)
-	if err != nil {
-		return nil, diag.NewErrorDiagnostic("error retrieving edge gateway", err.Error())
-	}
-	if anyEdgeGateway == nil {
-		return nil, diag.NewErrorDiagnostic("error retrieving edge gateway", "edge gateway is a nil object")
-	}
-	id := anyEdgeGateway.EdgeGateway.OwnerRef.ID
-
-	return &id, nil
-}
-
-// Get IP Pool information data from network.
-func GetIPRanges(network *govcd.OpenApiOrgVdcNetwork) []staticIPPool {
-	ipPools := []staticIPPool{}
-
-	for _, ipRange := range network.OpenApiOrgVdcNetwork.Subnets.Values[0].IPRanges.Values {
-		ipPool := staticIPPool{
-			StartAddress: types.StringValue(ipRange.StartAddress),
-			EndAddress:   types.StringValue(ipRange.EndAddress),
-		}
-		ipPools = append(ipPools, ipPool)
-	}
-	return ipPools
 }

--- a/templates/resources/network_isolated.md.tmpl
+++ b/templates/resources/network_isolated.md.tmpl
@@ -9,6 +9,53 @@ description: |-
 
 {{ .Description | trimspace }}
 
+
+## How to migrate existing resources
+
+Original configuration:
+
+{{ tffile .ExampleFile }}
+
+Migrated configuration:
+
+Rename the resource to `cloudavenue_vdc_network_isolated` and add the `moved` block to the configuration:
+
+```hcl
+resource "cloudavenue_vdc_network_isolated" "example" {
+  name = "my-isolated-network"
+  vdc  = cloudavenue_vdc.example.name
+
+  gateway       = "192.168.0.1"
+  prefix_length = 24
+
+  dns1       = "192.168.0.2"
+  dns2       = "192.168.0.3"
+  dns_suffix = "example.local"
+}
+
+moved {
+  from = cloudavenue_network_isolated.example
+  to   = cloudavenue_vdc_network_isolated.example
+}
+```
+
+Run `terraform plan` and `terraform apply` to migrate the resource.
+
+Example of terraform plan output:
+
+```shell
+Terraform will perform the following actions:
+
+  # cloudavenue_network_isolated.example has moved to cloudavenue_vdc_network_isolated.example
+    resource "cloudavenue_vdc_network_isolated" "example" {
+        id                 = "urn:vcloud:network:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        name               = "rsx-example-isolated-network"
+        # (9 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+```
+
 {{ if .HasExample -}}
 ## Example Usage
 


### PR DESCRIPTION
### Description of your changes

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```hcl
resource "cloudavenue_vdc_network_isolated" "example" {
  vdc         = cloudavenue_vdc.example2.name
  name        = "rsx-example-isolated-network"
  description = "My isolated Org VDC network"

  gateway       = "192.168.168.254"
  prefix_length = 24

  dns1       = "8.8.8.8"
  dns2       = "8.8.4.4"
  dns_suffix = "example.com"
}

moved {
  from = cloudavenue_network_isolated.example
  to   = cloudavenue_vdc_network_isolated.example
}
```

```
cloudavenue_vdc.example2: Refreshing state... [id=urn:vcloud:vdc:xxx]
cloudavenue_vdc_network_isolated.example: Refreshing state... [id=urn:vcloud:network:xxx]
data.cloudavenue_edgegateway.example: Read complete after 4s [id=urn:vcloud:gateway:xxx]

Terraform will perform the following actions:

  # cloudavenue_network_isolated.example has moved to cloudavenue_vdc_network_isolated.example
    resource "cloudavenue_vdc_network_isolated" "example" {
        id                 = "urn:vcloud:network:xxx"
        name               = "rsx-example-isolated-network"
        # (9 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes


Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```