### PR TITLE
fix: datasource `cloudavenue_vdc` not returning storage_profiles 

### DIFF
--- a/.changelog/934.txt
+++ b/.changelog/934.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`datasource/cloudavenue_vdc` - Fixed a bug where the datasource was not returning the `storage_profiles` attribute.
+```

--- a/internal/provider/vdc/vdc_datasource.go
+++ b/internal/provider/vdc/vdc_datasource.go
@@ -81,7 +81,11 @@ func (d *vdcDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	dataResource.Name = data.Name
 
 	// Read data from the API
-	dataRefreshed, _, diags := s.read(ctx, dataResource)
+	dataRefreshed, found, diags := s.read(ctx, dataResource)
+	if !found {
+		resp.Diagnostics.AddError("VDC not found", fmt.Sprintf("The VDC with the name %q was not found", data.Name.ValueString()))
+		return
+	}
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -97,6 +101,7 @@ func (d *vdcDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	data.ServiceClass = dataRefreshed.ServiceClass
 	data.StorageBillingModel = dataRefreshed.StorageBillingModel
 	data.VCPUInMhz = dataRefreshed.VCPUInMhz
+	data.StorageProfiles = dataRefreshed.StorageProfiles
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/testsacc/vdc_datasource_test.go
+++ b/internal/testsacc/vdc_datasource_test.go
@@ -43,16 +43,19 @@ func (r *VDCDataSource) DependenciesConfig() (resp testsacc.DependenciesConfigRe
 
 func (r *VDCDataSource) Tests(ctx context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
 	return map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test{
-		// * Test One (example)
-		"example": func(_ context.Context, _ string) testsacc.Test {
+		"example": func(_ context.Context, resourceName string) testsacc.Test {
 			return testsacc.Test{
-				// ! Create testing
+				CommonChecks: GetResourceConfig()[VDCResourceName]().GetDefaultChecks(),
 				Create: testsacc.TFConfig{
 					TFConfig: `
 					data "cloudavenue_vdc" "example" {
 						name = cloudavenue_vdc.example.name
 					}`,
-					Checks: GetResourceConfig()[VDCResourceName]().GetDefaultChecks(),
+					Checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceName, "storage_profiles.0.class", "gold"),
+						resource.TestCheckResourceAttr(resourceName, "storage_profiles.0.default", "true"),
+						resource.TestCheckResourceAttr(resourceName, "storage_profiles.0.limit", "500"),
+					},
 				},
 			}
 		},


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
--- PASS: TestAccVDCDataSource (71.01s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  71.557s
```