### PR TITLE
chore: `cloudavenue_publicip` return edge name and id in tfstate

### DIFF
--- a/.changelog/940.txt
+++ b/.changelog/940.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/cloudavenue_publicip` - Now the `edge_gateway_name` and `edge_gateway_id` are stored in the state file.
+```

--- a/internal/provider/publicip/publicip_resource.go
+++ b/internal/provider/publicip/publicip_resource.go
@@ -230,15 +230,6 @@ func (r *publicIPResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	// Fix after refacto (#697) - https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/pull/697/files#diff-aaea8073b6a3d4e8396f36585bf313c70c96798378be2bfe673cf357554f2d0fL56
-	if plan.EdgeGatewayID.IsNull() && state.EdgeGatewayID.IsKnown() {
-		state.EdgeGatewayID.SetNull()
-	}
-
-	if plan.EdgeGatewayName.IsNull() && state.EdgeGatewayName.IsKnown() {
-		state.EdgeGatewayName.SetNull()
-	}
-
 	/*
 		Implement the resource read here
 	*/
@@ -365,6 +356,8 @@ func (r *publicIPResource) read(_ context.Context, planOrState *publicIPResource
 
 	stateRefreshed.ID.Set(pubIP.UplinkIP)
 	stateRefreshed.PublicIP.Set(pubIP.UplinkIP)
+	stateRefreshed.EdgeGatewayID.Set(r.edgegw.EdgeGateway.ID)
+	stateRefreshed.EdgeGatewayName.Set(r.edgegw.EdgeGateway.Name)
 
 	return stateRefreshed, true, nil
 }

--- a/internal/provider/publicip/publicip_schema.go
+++ b/internal/provider/publicip/publicip_schema.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
-	schemaD "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	schemaR "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -59,6 +58,7 @@ func publicIPSchema() superschema.Schema {
 			"edge_gateway_name": superschema.SuperStringAttribute{
 				Common: &schemaR.StringAttribute{
 					MarkdownDescription: "The name of the Edge Gateway.",
+					Computed:            true,
 				},
 				Resource: &schemaR.StringAttribute{
 					Optional: true,
@@ -68,14 +68,12 @@ func publicIPSchema() superschema.Schema {
 					Validators: []validator.String{
 						stringvalidator.ExactlyOneOf(path.MatchRoot("edge_gateway_name"), path.MatchRoot("edge_gateway_id")),
 					},
-				},
-				DataSource: &schemaD.StringAttribute{
-					Computed: true,
 				},
 			},
 			"edge_gateway_id": superschema.SuperStringAttribute{
 				Common: &schemaR.StringAttribute{
 					MarkdownDescription: "The ID of the Edge Gateway.",
+					Computed:            true,
 				},
 				Resource: &schemaR.StringAttribute{
 					Optional: true,
@@ -85,9 +83,6 @@ func publicIPSchema() superschema.Schema {
 					Validators: []validator.String{
 						stringvalidator.ExactlyOneOf(path.MatchRoot("edge_gateway_name"), path.MatchRoot("edge_gateway_id")),
 					},
-				},
-				DataSource: &schemaD.StringAttribute{
-					Computed: true,
 				},
 			},
 		},

--- a/internal/testsacc/publicip_resource_test.go
+++ b/internal/testsacc/publicip_resource_test.go
@@ -45,24 +45,38 @@ func (r *PublicIPResource) Tests(ctx context.Context) map[testsacc.TestName]func
 	return map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test{
 		"example": func(_ context.Context, resourceName string) testsacc.Test {
 			return testsacc.Test{
-				CommonChecks: []resource.TestCheckFunc{},
+				CommonChecks: []resource.TestCheckFunc{
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
+					resource.TestCheckResourceAttrWith(resourceName, "edge_gateway_id", urn.TestIsType(urn.Gateway)),
+					resource.TestCheckResourceAttrSet(resourceName, "edge_gateway_name"),
+				},
 				// ! Create testing
 				Create: testsacc.TFConfig{
 					TFConfig: `
 					resource "cloudavenue_publicip" "example" {
 					  edge_gateway_id = cloudavenue_edgegateway.example.id
 					}`,
-					Checks: []resource.TestCheckFunc{
-						resource.TestCheckResourceAttrSet(resourceName, "id"),
-						resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
-						resource.TestCheckResourceAttrWith(resourceName, "edge_gateway_id", urn.TestIsType(urn.Gateway)),
-						resource.TestCheckNoResourceAttr(resourceName, "edge_gateway_name"),
+					Checks: []resource.TestCheckFunc{},
+				},
+				Updates: []testsacc.TFConfig{
+					{
+						TFConfig: `
+						resource "cloudavenue_publicip" "example" {
+						  edge_gateway_name = cloudavenue_edgegateway.example.name
+					}`,
+						Checks: []resource.TestCheckFunc{},
 					},
 				},
 				// ! Imports testing
 				Imports: []testsacc.TFImport{
 					{
 						ImportStateIDBuilder: []string{"edge_gateway_id", "id"},
+						ImportState:          true,
+						ImportStateVerify:    true,
+					},
+					{
+						ImportStateIDBuilder: []string{"edge_gateway_name", "id"},
 						ImportState:          true,
 						ImportStateVerify:    true,
 					},
@@ -81,7 +95,7 @@ func (r *PublicIPResource) Tests(ctx context.Context) map[testsacc.TestName]func
 					Checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttrSet(resourceName, "id"),
 						resource.TestCheckResourceAttrSet(resourceName, "public_ip"),
-						resource.TestCheckNoResourceAttr(resourceName, "edge_gateway_id"),
+						resource.TestCheckResourceAttrWith(resourceName, "edge_gateway_id", urn.TestIsType(urn.Gateway)),
 						resource.TestCheckResourceAttrSet(resourceName, "edge_gateway_name"),
 					},
 				},
@@ -89,6 +103,11 @@ func (r *PublicIPResource) Tests(ctx context.Context) map[testsacc.TestName]func
 				Imports: []testsacc.TFImport{
 					{
 						ImportStateIDBuilder: []string{"edge_gateway_name", "id"},
+						ImportState:          true,
+						ImportStateVerify:    true,
+					},
+					{
+						ImportStateIDBuilder: []string{"edge_gateway_id", "id"},
 						ImportState:          true,
 						ImportStateVerify:    true,
 					},


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
--- PASS: TestAccPublicIPResource (347.53s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  348.072s
```