### PR TITLE
chore: improve error message vdcg security group

### DIFF
--- a/.changelog/1022.txt
+++ b/.changelog/1022.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-`resource/cloudavenue_vdcg_security_group` - Improve error message when trying to create a security group with an invalid network.
+`resource/cloudavenue_vdcg_security_group` - Improved error message for creating a security group with an invalid network.
 ```

--- a/.changelog/1022.txt
+++ b/.changelog/1022.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/cloudavenue_vdcg_security_group` - Improve error message when trying to create a security group with an invalid network.
+```

--- a/docs/resources/vdcg_security_group.md
+++ b/docs/resources/vdcg_security_group.md
@@ -13,11 +13,14 @@ The `cloudavenue_vdcg_security_group` resource allows you to manage a security g
 
 ```terraform
 resource "cloudavenue_vdcg_security_group" "example" {
+  name        = "example"
+  description = "Example security group"
+
   vdc_group_id = cloudavenue_vdcg_network_isolated.example.vdc_group_id
-  name         = "example"
-  description  = "Example security group"
+
   member_org_network_ids = [
-    cloudavenue_vdcg_network_isolated.example.id
+    cloudavenue_vdcg_network_isolated.example.id,
+    cloudavenue_vdcg_network_routed.example.id
   ]
 }
 ```
@@ -32,7 +35,7 @@ resource "cloudavenue_vdcg_security_group" "example" {
 ### Optional
 
 - `description` (String) The description of the security group.
-- `member_org_network_ids` (Set of String) The list of organization network IDs to which the security group is applied. Element value must satisfy all validations: must be a valid URN + must start with "urn:vcloud:network:".
+- `member_org_network_ids` (Set of String) The list of organization network IDs to which the security group is applied. Only `cloudavenue_vdcg_network_routed` or `cloudavenue_vdcg_network_isolated` are allowed. If you want to add `cloudavenue_edgegateway_network_routed` to the security group, you need to use the `cloudavenue_edgegateway_security_group` resource. Element value must satisfy all validations: must be a valid URN + must start with "urn:vcloud:network:".
 - `vdc_group_id` (String) <i style="color:red;font-weight: bold">(ForceNew)</i> The ID of the VDC Group to which the security group belongs. Ensure that at least one attribute from this collection is set: [vdc_group_name,vdc_group_id]. This value must start with `urn:vcloud:vdcGroup:`.
 - `vdc_group_name` (String) <i style="color:red;font-weight: bold">(ForceNew)</i> The name of the VDC Group to which the security group belongs. Ensure that at least one attribute from this collection is set: [vdc_group_name,vdc_group_id].
 

--- a/docs/resources/vdcg_security_group.md
+++ b/docs/resources/vdcg_security_group.md
@@ -16,7 +16,7 @@ resource "cloudavenue_vdcg_security_group" "example" {
   name        = "example"
   description = "Example security group"
 
-  vdc_group_id = cloudavenue_vdcg_network_isolated.example.vdc_group_id
+  vdc_group_id = cloudavenue_vdcg.example.id
 
   member_org_network_ids = [
     cloudavenue_vdcg_network_isolated.example.id,

--- a/examples/resources/cloudavenue_vdcg_security_group/resource.tf
+++ b/examples/resources/cloudavenue_vdcg_security_group/resource.tf
@@ -1,8 +1,11 @@
 resource "cloudavenue_vdcg_security_group" "example" {
+  name        = "example"
+  description = "Example security group"
+
   vdc_group_id = cloudavenue_vdcg_network_isolated.example.vdc_group_id
-  name         = "example"
-  description  = "Example security group"
+
   member_org_network_ids = [
-    cloudavenue_vdcg_network_isolated.example.id
+    cloudavenue_vdcg_network_isolated.example.id,
+    cloudavenue_vdcg_network_routed.example.id
   ]
 }

--- a/examples/resources/cloudavenue_vdcg_security_group/resource.tf
+++ b/examples/resources/cloudavenue_vdcg_security_group/resource.tf
@@ -2,7 +2,7 @@ resource "cloudavenue_vdcg_security_group" "example" {
   name        = "example"
   description = "Example security group"
 
-  vdc_group_id = cloudavenue_vdcg_network_isolated.example.vdc_group_id
+  vdc_group_id = cloudavenue_vdcg.example.id
 
   member_org_network_ids = [
     cloudavenue_vdcg_network_isolated.example.id,

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.23.0
 
 toolchain go1.24.0
 
-replace github.com/orange-cloudavenue/cloudavenue-sdk-go => ../cloudavenue-sdk-go
-
 require (
 	github.com/aws/aws-sdk-go v1.55.6
 	github.com/cilium/fake v0.7.0
@@ -22,7 +20,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.36.1
 	github.com/iancoleman/strcase v0.3.0
 	github.com/madflojo/testcerts v1.4.0
-	github.com/orange-cloudavenue/cloudavenue-sdk-go v0.23.0
+	github.com/orange-cloudavenue/cloudavenue-sdk-go v0.24.0
 	github.com/orange-cloudavenue/common-go/print v0.0.0-20250109171729-2be550d5d3ac
 	github.com/orange-cloudavenue/common-go/utils v0.0.0-20240119163616-66b473d92339
 	github.com/orange-cloudavenue/terraform-plugin-framework-planmodifiers v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
+github.com/orange-cloudavenue/cloudavenue-sdk-go v0.24.0 h1:sww+B0EZgpZbm1/GmQ42hP4Cbp4xM9ZnbMrSl99UTtI=
+github.com/orange-cloudavenue/cloudavenue-sdk-go v0.24.0/go.mod h1:JC9sN6jDrG3Sa3k4JvM+xa5dzDhOSJQVNmvC5CKZSPM=
 github.com/orange-cloudavenue/common-go/print v0.0.0-20250109171729-2be550d5d3ac h1:f1Fd70+PMDTK6FE4gHdNfoHSQHLn5pfJMTjZPzOWZtc=
 github.com/orange-cloudavenue/common-go/print v0.0.0-20250109171729-2be550d5d3ac/go.mod h1:IYtCusqpEGS0dhC6F8X9GHrrt1gp1zHaNhSKGYV59Xg=
 github.com/orange-cloudavenue/common-go/utils v0.0.0-20240119163616-66b473d92339 h1:DEKcWLGbEhu/I6kn9NAXhVCFrbPhR+Ef7oLmpLVnnPM=

--- a/internal/provider/vdcg/network_routed_resource.go
+++ b/internal/provider/vdcg/network_routed_resource.go
@@ -403,7 +403,7 @@ func (r *NetworkRoutedResource) read(ctx context.Context, planOrState *NetworkRo
 }
 
 // getEdgeGateway retrieves the edge gateway and add in the models edgegateway id and name.
-func (r *NetworkRoutedResource) getEdgeGateway(ctx context.Context, rm *NetworkRoutedModel) diag.Diagnostics {
+func (r *NetworkRoutedResource) getEdgeGateway(_ context.Context, rm *NetworkRoutedModel) diag.Diagnostics {
 	diags := diag.Diagnostics{}
 
 	idOrName := rm.EdgeGatewayID.Get()

--- a/internal/provider/vdcg/security_group_resource.go
+++ b/internal/provider/vdcg/security_group_resource.go
@@ -400,7 +400,7 @@ func (r *SecurityGroupResource) validateNetworks(ctx context.Context, rm *Securi
 		}
 		switch { // = true
 		case net.IsIsolated() && !net.IsShared():
-			diags.AddError(fmt.Sprintf("Error creating security group %s", rm.Name.Get()), fmt.Sprintf("EdgeGateway security group doesn't support isolated network (%s)", network))
+			diags.AddError(fmt.Sprintf("Error creating security group %s", rm.Name.Get()), fmt.Sprintf("VDCG security group doesn't support VDC isolated network (%s)", network))
 		case net.IsRouted() && !net.IsShared():
 			diags.AddError(fmt.Sprintf("Error creating security group %s", rm.Name.Get()), fmt.Sprintf("Routed network %s is connected to EdgeGateway, please use the EdgeGateway resource (cloudavenue_edgegateway_security_group) instead", network))
 		}

--- a/internal/provider/vdcg/security_group_resource.go
+++ b/internal/provider/vdcg/security_group_resource.go
@@ -115,6 +115,11 @@ func (r *SecurityGroupResource) Create(ctx context.Context, req resource.CreateR
 		Implement the resource creation logic here.
 	*/
 
+	resp.Diagnostics.Append(r.validateNetworks(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	mutex.GlobalMutex.KvLock(ctx, r.vdcGroup.GetID())
 	defer mutex.GlobalMutex.KvUnlock(ctx, r.vdcGroup.GetID())
 
@@ -206,6 +211,11 @@ func (r *SecurityGroupResource) Update(ctx context.Context, req resource.UpdateR
 	/*
 		Implement the resource update here
 	*/
+
+	resp.Diagnostics.Append(r.validateNetworks(ctx, plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	mutex.GlobalMutex.KvLock(ctx, r.vdcGroup.GetID())
 	defer mutex.GlobalMutex.KvUnlock(ctx, r.vdcGroup.GetID())
@@ -369,4 +379,35 @@ func (r *SecurityGroupResource) read(ctx context.Context, planOrState *SecurityG
 	}
 
 	return stateRefreshed, true, diags
+}
+
+// validateNetworks validates the networks in the security group.
+func (r *SecurityGroupResource) validateNetworks(ctx context.Context, rm *SecurityGroupModel) (diags diag.Diagnostics) {
+	// Add Validation to check the network
+	// Allow only networks routed shared && isolated shared
+
+	networks, d := rm.Members.Get(ctx)
+	if d.HasError() {
+		diags.Append(d...)
+		return
+	}
+
+	for _, network := range networks {
+		net, err := r.vdcGroup.GetNetworkRouted(network)
+		if err != nil {
+			diags.AddError(fmt.Sprintf("Error retrieving network %s", network), err.Error())
+			continue
+		}
+		switch { // = true
+		case net.IsIsolated() && !net.IsShared():
+			diags.AddError(fmt.Sprintf("Error creating security group %s", rm.Name.Get()), fmt.Sprintf("EdgeGateway security group doesn't support isolated network (%s)", network))
+		case net.IsRouted() && !net.IsShared():
+			diags.AddError(fmt.Sprintf("Error creating security group %s", rm.Name.Get()), fmt.Sprintf("Routed network %s is connected to EdgeGateway, please use the EdgeGateway resource (cloudavenue_edgegateway_security_group) instead", network))
+		}
+	}
+	if diags.HasError() {
+		return
+	}
+
+	return nil
 }

--- a/internal/provider/vdcg/security_group_schema.go
+++ b/internal/provider/vdcg/security_group_schema.go
@@ -114,7 +114,8 @@ func securityGroupSchema(_ context.Context) superschema.Schema {
 					MarkdownDescription: "The list of organization network IDs to which the security group is applied.",
 				},
 				Resource: &schemaR.SetAttribute{
-					Optional: true,
+					MarkdownDescription: "Only `cloudavenue_vdcg_network_routed` or `cloudavenue_vdcg_network_isolated` are allowed. If you want to add `cloudavenue_edgegateway_network_routed` to the security group, you need to use the `cloudavenue_edgegateway_security_group` resource.",
+					Optional:            true,
 					Validators: []validator.Set{
 						setvalidator.ValueStringsAre(fstringvalidator.IsURN(), fstringvalidator.PrefixContains(urn.Network.String())),
 					},

--- a/internal/testsacc/vdcg_security_group_resource_test.go
+++ b/internal/testsacc/vdcg_security_group_resource_test.go
@@ -140,7 +140,7 @@ func (r *VDCGSecurityGroupResource) Tests(ctx context.Context) map[testsacc.Test
 				Create: testsacc.TFConfig{
 					TFConfig: testsacc.GenerateFromTemplate(resourceName, `
 					resource "cloudavenue_vdcg_security_group" "example_with_networks" {
-						vdc_group_id  = cloudavenue_vdcg_network_isolated.example.vdc_group_id
+						vdc_group_id  = cloudavenue_vdcg.example.id
 						name            = {{ generate . "name" }}
 						description     = {{ generate . "description" }}
 						member_org_network_ids = [
@@ -220,7 +220,7 @@ func (r *VDCGSecurityGroupResource) Tests(ctx context.Context) map[testsacc.Test
 						name            = {{ generate . "name" }}
 						description     = {{ generate . "description" }}
 						
-						vdc_group_id  = cloudavenue_vdcg_network_isolated.example.vdc_group_id
+						vdc_group_id  = cloudavenue_vdcg.example.id
 						member_org_network_ids = [
 						  cloudavenue_vdcg_network_routed.example.id
 						]
@@ -241,7 +241,7 @@ func (r *VDCGSecurityGroupResource) Tests(ctx context.Context) map[testsacc.Test
 							name            = {{ generate . "name" }}
 							description     = {{ generate . "description" }}
 							
-							vdc_group_id  = cloudavenue_vdcg_network_isolated.example.vdc_group_id
+							vdc_group_id  = cloudavenue_vdcg.example.id
 							member_org_network_ids = [
 							  cloudavenue_vdcg_network_routed.example.id,
 							  cloudavenue_vdc_network_isolated.example.id
@@ -249,7 +249,7 @@ func (r *VDCGSecurityGroupResource) Tests(ctx context.Context) map[testsacc.Test
 						  }`),
 						TFAdvanced: testsacc.TFAdvanced{
 							ExpectNonEmptyPlan: true,
-							ExpectError:        regexp.MustCompile("EdgeGateway security group doesn't support isolated network"),
+							ExpectError:        regexp.MustCompile("VDCG security group doesn't support VDC isolated network"),
 						},
 					},
 					// * Update fail add edgegateway_network_routed
@@ -259,7 +259,7 @@ func (r *VDCGSecurityGroupResource) Tests(ctx context.Context) map[testsacc.Test
 							name            = {{ generate . "name" }}
 							description     = {{ generate . "description" }}
 							
-							vdc_group_id  = cloudavenue_vdcg_network_isolated.example.vdc_group_id
+							vdc_group_id  = cloudavenue_vdcg.example.id
 							member_org_network_ids = [
 								cloudavenue_vdcg_network_routed.example.id,
 								cloudavenue_edgegateway_network_routed.example.id
@@ -277,7 +277,7 @@ func (r *VDCGSecurityGroupResource) Tests(ctx context.Context) map[testsacc.Test
 							name            = {{ generate . "name" }}
 							description     = {{ generate . "description" }}
 							
-							vdc_group_id  = cloudavenue_vdcg_network_isolated.example.vdc_group_id
+							vdc_group_id  = cloudavenue_vdcg.example.id
 							member_org_network_ids = [
 							  cloudavenue_vdcg_network_routed.example.id,
 							  cloudavenue_vdcg_network_isolated.example.id


### PR DESCRIPTION

This pull request includes several enhancements and fixes for the `cloudavenue_vdcg_security_group` resource. The most important changes include improving error messages, updating documentation, adding validation for network members, and updating dependencies.

Enhancements to error messages and validation:

* [`.changelog/1022.txt`](diffhunk://#diff-2ebaa461288a6dfa27c640074c088ba58ff6f7afec185fd730dd4113dd7874d4R1-R3): Improved error message for creating a security group with an invalid network.
* [`internal/provider/vdcg/security_group_resource.go`](diffhunk://#diff-ee32c160a16434657d734044561f32afd345ea9ba2e01f03de3eee19a1044877R118-R122): Added `validateNetworks` function to validate networks in the security group during creation and update. [[1]](diffhunk://#diff-ee32c160a16434657d734044561f32afd345ea9ba2e01f03de3eee19a1044877R118-R122) [[2]](diffhunk://#diff-ee32c160a16434657d734044561f32afd345ea9ba2e01f03de3eee19a1044877R215-R219) [[3]](diffhunk://#diff-ee32c160a16434657d734044561f32afd345ea9ba2e01f03de3eee19a1044877R383-R413)

Documentation updates:

* [`docs/resources/vdcg_security_group.md`](diffhunk://#diff-478cbb96d087d937157cbf156445dbfc7eca5945a4a1437ee06ac899ae4dac54L16-R23): Updated example and descriptions to reflect the new validation rules for `member_org_network_ids`. [[1]](diffhunk://#diff-478cbb96d087d937157cbf156445dbfc7eca5945a4a1437ee06ac899ae4dac54L16-R23) [[2]](diffhunk://#diff-478cbb96d087d937157cbf156445dbfc7eca5945a4a1437ee06ac899ae4dac54L35-R38)

Dependency updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L25-R23): Updated `cloudavenue-sdk-go` dependency to version 0.24.0.

Testing improvements:

* [`internal/testsacc/vdcg_security_group_resource_test.go`](diffhunk://#diff-09ab0cf5122a1dccf05af4ae11969e0392023dc0f23dc7134ae8f47b508d6d9aR202-R317): Added advanced test cases for `cloudavenue_vdcg_security_group` resource to cover new validation rules.

### How has this code been tested

```
--- PASS: TestAccVDCGSecurityGroupResource (702.20s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  702.790s
```