### PR TITLE
fix: nil pointer in the `cloudavenue_edgegateway_network_routed`

### DIFF
--- a/.changelog/1045.txt
+++ b/.changelog/1045.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/edgegateway_network_routed` - Fixed a crash in the `cloudavenue_edgegateway_network_routed` resource read operation caused by a nil pointer dereference.
+```

--- a/internal/provider/edgegw/network_routed_resource.go
+++ b/internal/provider/edgegw/network_routed_resource.go
@@ -62,6 +62,7 @@ func (r *NetworkRoutedResource) Init(ctx context.Context, rm *NetworkRoutedModel
 	r.edgegw, err = r.client.CAVSDK.V1.EdgeGateway.Get(idOrName)
 	if err != nil {
 		diags.AddError("Error retrieving Edge Gateway", fmt.Sprintf("Error: %s", err.Error()))
+		return
 	}
 
 	rm.EdgeGatewayID.Set(r.edgegw.GetURN())


### PR DESCRIPTION
This pull request includes a bug fix and a minor improvement to error handling in the `cloudavenue_edgegateway_network_routed` resource. The most important changes are:

Bug fix:
* [`.changelog/1045.txt`](diffhunk://#diff-f2ea5c8bbbfd14d70a8d4cff8a7ffc685a8e6352583fd1e2bd69f72d03c8a6cbR1-R3): Added a release note indicating that a crash caused by a nil pointer dereference in the `cloudavenue_edgegateway_network_routed` resource read operation has been fixed.

Error handling improvement:
* [`internal/provider/edgegw/network_routed_resource.go`](diffhunk://#diff-73dddf1dea18bbcfe5b7bd4b72e5bdcb7cc2e7af70f8945917af1e45e79531b8R65): Added a return statement to the `Init` function to prevent further execution after an error is encountered while retrieving the Edge Gateway.