### PR TITLE
chore: fix deprecated goreleaser notice

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ before:
     - go mod tidy
 
 snapshot:
-  name_template: "{{ .Tag }}"
+  version_template: "{{ .Tag }}"
 
 builds:
 - env:
@@ -35,8 +35,8 @@ builds:
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
-  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  - formats: [ 'zip' ]
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   extra_files:
     - glob: 'terraform-registry-manifest.json'


### PR DESCRIPTION
This pull request includes changes to the `.goreleaser.yml` file to update the configuration for building and releasing Go projects. The most important changes include modifying the snapshot naming template and adjusting the format specification for archives.

Configuration updates:

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L10-R10): Changed `name_template` to `version_template` under the `snapshot` section to better reflect the purpose of the template.
* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L38-R38): Updated the `archives` section to specify formats using an array, which enhances flexibility and clarity in defining multiple formats.