### PR TITLE
chore!: remove attribute owner_type for resource/datasource cloudavenue_edgegateway

### DIFF
--- a/.changelog/952.txt
+++ b/.changelog/952.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+`cloudavenue_edgegateway` - Announced in the release [v0.24.0](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/releases/tag/v0.24.0) the attribute `owner_type` for resource/datasource `cloudavenue_edgegateway` and datasource `cloudavenue_edgegateways`, are now removed.
+```

--- a/docs/data-sources/edgegateway.md
+++ b/docs/data-sources/edgegateway.md
@@ -34,8 +34,5 @@ output "gateway" {
 - `description` (String) The description of the Edge Gateway.
 - `id` (String) The ID of the Edge Gateway.
 - `owner_name` (String) The name of the Edge Gateway owner. It can be a VDC or a VDC Group name.
-- `owner_type` (String, Deprecated) The type of the Edge Gateway owner. Value must be one of : `vdc`, `vdc-group`. 
-
- ~> **Attribute deprecated** Remove the `owner_type` attribute configuration, it will be removed in the version [`v0.32.0`](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/20) of the provider. See the [GitHub issue](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/952) for more information.
 - `tier0_vrf_name` (String) The name of the Tier-0 VRF to which the Edge Gateway is attached.
 

--- a/docs/data-sources/edgegateways.md
+++ b/docs/data-sources/edgegateways.md
@@ -37,6 +37,5 @@ Read-Only:
 - `lb_enabled` (Boolean) Load Balancing state on the Edge Gateway.
 - `name` (String) The name of the Edge Gateway.
 - `owner_name` (String) The name of the Edge Gateway owner.
-- `owner_type` (String) The type of the Edge Gateway owner. Must be vdc or vdc-group.
 - `tier0_vrf_name` (String) The name of the Tier-0 VRF to which the Edge Gateway is attached.
 

--- a/docs/resources/edgegateway.md
+++ b/docs/resources/edgegateway.md
@@ -42,9 +42,6 @@ resource "cloudavenue_edgegateway" "example" {
 - `bandwidth` (Number) The bandwidth in `Mbps` of the Edge Gateway. If no value is specified, the bandwidth is automatically calculated based on the remaining bandwidth of the Tier-0 VRF. More information can be found [here](#bandwidth-attribute).
 
 !> **Warning** This attribute is not supported if your Tier-0 VRF has a class of service `DEDICATED`. This is due to a bug in the API (See [#1068](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1069)).
-- `owner_type` (String, Deprecated) The type of the Edge Gateway owner. Value must be one of : `vdc`, `vdc-group`. 
-
- ~> **Attribute deprecated** Remove the `owner_type` attribute configuration, it will be removed in the version [`v0.32.0`](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/20) of the provider. See the [GitHub issue](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/952) for more information.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only

--- a/internal/provider/edgegw/edgegateway_datasource.go
+++ b/internal/provider/edgegw/edgegateway_datasource.go
@@ -86,7 +86,6 @@ func (d *edgeGatewayDataSource) Read(ctx context.Context, req datasource.ReadReq
 	data.ID.Set(urn.Normalize(urn.Gateway, edgegw.GetID()).String())
 	data.Tier0VrfID.Set(edgegw.GetTier0VrfID())
 	data.OwnerName.Set(edgegw.GetOwnerName())
-	data.OwnerType.Set(string(edgegw.GetOwnerType()))
 	data.Description.Set(edgegw.GetDescription())
 	data.Bandwidth.SetInt(edgegw.GetBandwidth())
 

--- a/internal/provider/edgegw/edgegateway_resource.go
+++ b/internal/provider/edgegw/edgegateway_resource.go
@@ -28,7 +28,6 @@ import (
 	commoncloudavenue "github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/common/cloudavenue"
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
 	v1 "github.com/orange-cloudavenue/cloudavenue-sdk-go/v1"
-
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/client"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/metrics"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/cloudavenue"

--- a/internal/provider/edgegw/edgegateway_schema.go
+++ b/internal/provider/edgegw/edgegateway_schema.go
@@ -12,15 +12,11 @@ package edgegw
 import (
 	superschema "github.com/orange-cloudavenue/terraform-plugin-framework-superschema"
 
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-
 	schemaD "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	schemaR "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 )
 
 /*
@@ -81,32 +77,6 @@ func edgegwSchema() superschema.Schema {
 					Required: true,
 					PlanModifiers: []planmodifier.String{
 						stringplanmodifier.RequiresReplace(),
-					},
-				},
-				DataSource: &schemaD.StringAttribute{
-					Computed: true,
-				},
-			},
-			"owner_type": &superschema.SuperStringAttribute{
-				Deprecated: &superschema.Deprecated{
-					DeprecationMessage:                "This attribute is deprecated and not longer used.",
-					ComputeMarkdownDeprecationMessage: true,
-					Removed:                           true,
-					FromAttributeName:                 "owner_type",
-					TargetRelease:                     "v0.32.0",
-					LinkToIssue:                       "https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/952",
-					LinkToMilestone:                   "https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/20",
-				},
-				Common: &schemaR.StringAttribute{
-					MarkdownDescription: "The type of the Edge Gateway owner.",
-					Validators: []validator.String{
-						stringvalidator.OneOf("vdc", "vdc-group"),
-					},
-				},
-				Resource: &schemaR.StringAttribute{
-					Optional: true,
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.UseStateForUnknown(),
 					},
 				},
 				DataSource: &schemaD.StringAttribute{

--- a/internal/provider/edgegw/edgegateway_types.go
+++ b/internal/provider/edgegw/edgegateway_types.go
@@ -22,7 +22,6 @@ type edgeGatewayResourceModel struct {
 	ID          supertypes.StringValue `tfsdk:"id"`
 	Tier0VrfID  supertypes.StringValue `tfsdk:"tier0_vrf_name"`
 	Name        supertypes.StringValue `tfsdk:"name"`
-	OwnerType   supertypes.StringValue `tfsdk:"owner_type"`
 	OwnerName   supertypes.StringValue `tfsdk:"owner_name"`
 	Description supertypes.StringValue `tfsdk:"description"`
 	Bandwidth   supertypes.Int64Value  `tfsdk:"bandwidth"`
@@ -32,7 +31,6 @@ type edgeGatewayDatasourceModel struct {
 	ID          supertypes.StringValue `tfsdk:"id"`
 	Tier0VrfID  supertypes.StringValue `tfsdk:"tier0_vrf_name"`
 	Name        supertypes.StringValue `tfsdk:"name"`
-	OwnerType   supertypes.StringValue `tfsdk:"owner_type"`
 	OwnerName   supertypes.StringValue `tfsdk:"owner_name"`
 	Description supertypes.StringValue `tfsdk:"description"`
 	Bandwidth   supertypes.Int64Value  `tfsdk:"bandwidth"`

--- a/internal/provider/edgegw/edgegateways_datasource.go
+++ b/internal/provider/edgegw/edgegateways_datasource.go
@@ -89,7 +89,6 @@ func (d *edgeGatewaysDataSource) Read(ctx context.Context, req datasource.ReadRe
 		gw.ID.Set(urn.Normalize(urn.Gateway, edge.GetID()).String())
 		gw.Name.Set(edge.GetName())
 		gw.Description.Set(edge.GetDescription())
-		gw.OwnerType.Set(string(edge.GetOwnerType()))
 		gw.OwnerName.Set(edge.GetOwnerName())
 		gw.Tier0VrfName.Set(edge.GetT0())
 

--- a/internal/provider/edgegw/edgegateways_schema.go
+++ b/internal/provider/edgegw/edgegateways_schema.go
@@ -54,12 +54,6 @@ func edgeGatewaysSuperSchema(_ context.Context) superschema.Schema {
 							MarkdownDescription: "The ID of the Edge Gateway.",
 						},
 					},
-					"owner_type": superschema.SuperStringAttribute{
-						DataSource: &schemaD.StringAttribute{
-							Computed:            true,
-							MarkdownDescription: "The type of the Edge Gateway owner. Must be vdc or vdc-group.",
-						},
-					},
 					"owner_name": superschema.SuperStringAttribute{
 						DataSource: &schemaD.StringAttribute{
 							Computed:            true,

--- a/internal/provider/edgegw/edgegateways_types.go
+++ b/internal/provider/edgegw/edgegateways_types.go
@@ -23,7 +23,6 @@ type (
 		Tier0VrfName supertypes.StringValue `tfsdk:"tier0_vrf_name"`
 		Name         supertypes.StringValue `tfsdk:"name"`
 		ID           supertypes.StringValue `tfsdk:"id"`
-		OwnerType    supertypes.StringValue `tfsdk:"owner_type"`
 		OwnerName    supertypes.StringValue `tfsdk:"owner_name"`
 		Description  supertypes.StringValue `tfsdk:"description"`
 		LbEnabled    supertypes.BoolValue   `tfsdk:"lb_enabled"`

--- a/internal/testsacc/edgegw_edgegateway_resource_test.go
+++ b/internal/testsacc/edgegw_edgegateway_resource_test.go
@@ -194,57 +194,6 @@ func (r *EdgeGatewayResource) Tests(_ context.Context) map[testsacc.TestName]fun
 				},
 			}
 		},
-		"example_test_deprecated": func(_ context.Context, resourceName string) testsacc.Test {
-			return testsacc.Test{
-				CommonChecks: []resource.TestCheckFunc{
-					resource.TestCheckResourceAttrSet(resourceName, "owner_name"),
-
-					// Read-Only attributes
-					resource.TestCheckResourceAttrWith(resourceName, "id", urn.TestIsType(urn.Gateway)),
-					resource.TestMatchResourceAttr(resourceName, "tier0_vrf_name", regexp.MustCompile(regexpTier0VRFName)),
-					resource.TestCheckResourceAttrSet(resourceName, "description"),
-				},
-				CommonDependencies: func() (resp testsacc.DependenciesConfigResponse) {
-					resp.Append(GetResourceConfig()[VDCGResourceName]().GetDefaultConfig)
-					return
-				},
-				// ! Create testing
-				Create: testsacc.TFConfig{
-					TFConfig: testsacc.GenerateFromTemplate(resourceName, `
-					resource "cloudavenue_edgegateway" "example_test_deprecated" {
-						owner_name     = cloudavenue_vdcg.example.name
-						tier0_vrf_name = data.cloudavenue_tier0_vrf.example.name
-						bandwidth      = 25
-						owner_type     = "vdc-group"
-					  }`),
-					Checks: []resource.TestCheckFunc{
-						resource.TestCheckResourceAttr(resourceName, "owner_type", "vdc-group"),
-					},
-				},
-				// ! Updates testing
-				Updates: []testsacc.TFConfig{
-					{
-						TFConfig: testsacc.GenerateFromTemplate(resourceName, `
-						resource "cloudavenue_edgegateway" "example_test_deprecated" {
-							owner_name     = cloudavenue_vdcg.example.name
-							tier0_vrf_name = data.cloudavenue_tier0_vrf.example.name
-							bandwidth      = 25
-						  }`),
-						Checks: []resource.TestCheckFunc{
-							resource.TestCheckNoResourceAttr(resourceName, "owner_type"),
-						},
-					},
-				},
-				// ! Imports testing
-				Imports: []testsacc.TFImport{
-					{
-						ImportStateIDBuilder: []string{"name"},
-						ImportState:          true,
-						ImportStateVerify:    true,
-					},
-				},
-			}
-		},
 	}
 }
 


### PR DESCRIPTION
This pull request involves significant changes to the `cloudavenue_edgegateway` resource and associated data sources in the Terraform provider for CloudAvenue. The primary focus is the removal of the deprecated `owner_type` attribute, as announced in the release v0.24.0.

### Removal of `owner_type` attribute:

* [`.changelog/952.txt`](diffhunk://#diff-be4b2376c19ce89d9ba15c50649e385a70bc70586298c98d12c6d962143423edR1-R3): Announced the removal of the `owner_type` attribute for `cloudavenue_edgegateway` and `cloudavenue_edgegateways` in the release notes.
* [`docs/data-sources/edgegateway.md`](diffhunk://#diff-89c2823abf5da92cff35fbd81d352937d7194a326a504ddb7aba94a97d975af9L37-L39): Removed the `owner_type` attribute from the documentation for the Edge Gateway data source.
* [`docs/data-sources/edgegateways.md`](diffhunk://#diff-ba2df799ce42a75cd2f706fcfeba55ebf707140849cdb9e7032fa7f2de52f5edL40): Removed the `owner_type` attribute from the documentation for the Edge Gateways data source.
* [`docs/resources/edgegateway.md`](diffhunk://#diff-e80eb3f38c4090fdfdc57a16ee010bda5c6f61baeebc67fbf44f254ef886f867L43-L45): Removed the `owner_type` attribute from the documentation for the Edge Gateway resource.

### Codebase updates:

* [`internal/provider/edgegw/edgegateway_datasource.go`](diffhunk://#diff-e17fa68cee08549fb10bbe6e5b2ee0185bd4eb6cdedee6eff8386f6961377a36L89): Removed the `owner_type` attribute from the data source read function.
* [`internal/provider/edgegw/edgegateway_schema.go`](diffhunk://#diff-4520c2592d2c2ebecc503d71864ba267dda7c89e389cca31ab9a5bdf20f23768L90-L115): Removed the `owner_type` attribute and its validators from the schema definition.
* [`internal/provider/edgegw/edgegateway_types.go`](diffhunk://#diff-2cf303b5f51f1599d7cdb3233e9162cef2fd6f83974868b8b1133161644c1f54L25): Removed the `owner_type` field from the `edgeGatewayResourceModel` and `edgeGatewayDatasourceModel` types. [[1]](diffhunk://#diff-2cf303b5f51f1599d7cdb3233e9162cef2fd6f83974868b8b1133161644c1f54L25) [[2]](diffhunk://#diff-2cf303b5f51f1599d7cdb3233e9162cef2fd6f83974868b8b1133161644c1f54L35)
* [`internal/provider/edgegw/edgegateways_datasource.go`](diffhunk://#diff-04e54b4ffd3f4e86a7911e04703682243624ff8fa107ecb4b543790a551d450bL92): Removed the `owner_type` attribute from the Edge Gateways data source read function.
* [`internal/provider/edgegw/edgegateways_schema.go`](diffhunk://#diff-e11a3f0031b83c5b11cc607d922c790dcadd8cf674a6d0000a28e04defde18e7L57-L62): Removed the `owner_type` attribute from the Edge Gateways schema definition.
* [`internal/provider/edgegw/edgegateways_types.go`](diffhunk://#diff-c3b09f4d2336c5e350c24148c88acd873be02769e4192e891924879d6103afaaL26): Removed the `owner_type` field from the Edge Gateways data source model.

### Tests updates:

* [`internal/testsacc/edgegw_edgegateway_resource_test.go`](diffhunk://#diff-b71128a0a8542673aa7e16c2f971b206b6f2aff930b256b0bfc4b6d1e78c15cfL197-L247): Removed tests related to the deprecated `owner_type` attribute.