### PR TITLE
fix: create T1 if T0 dedicated

### DIFF
--- a/.changelog/1069.txt
+++ b/.changelog/1069.txt
@@ -1,3 +1,0 @@
-```release-note:bug
-`resource/cloudavenue_edgegateway` - Add Workaround where deactivate calculating remaining bandwidth and disallow to set it if the T0 VRF has a class of service `DEDICATED`. This is a workaround for a bug in the API and will be removed when the API is fixed.
-```

--- a/.changelog/1069.txt
+++ b/.changelog/1069.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_edgegateway` - Add Workaround where deactivate calculating remaining bandwidth and disallow to set it if the T0 VRF has a class of service `DEDICATED`. This is a workaround for a bug in the API and will be removed when the API is fixed.
+```

--- a/.changelog/1069.txt
+++ b/.changelog/1069.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-`resource/cloudavenue_edgegateway` - Add Workaround where deactivate calculating remaining bandwidth and disallow to set it if the T0 VRF has a class of service `DEDICATED`. This is a workaround for a bug in the API and will be removed when the API is fixed.
+`resource/cloudavenue_edgegateway` - Implement a workaround to deactivate the calculation of remaining bandwidth and prevent its configuration when the T0 VRF has a class of service set to DEDICATED. This workaround addresses a bug in the API and will be removed once the API issue is resolved.
 ```

--- a/docs/resources/edgegateway.md
+++ b/docs/resources/edgegateway.md
@@ -40,7 +40,7 @@ resource "cloudavenue_edgegateway" "example" {
 ### Optional
 
 - `bandwidth` (Number) The bandwidth in `Mbps` of the Edge Gateway. If no value is specified, the bandwidth is automatically calculated based on the remaining bandwidth of the Tier-0 VRF. More information can be found [here](#bandwidth-attribute).
-~> **Warning**: This attribute is not supported if your Tier-0 VRF have class of service `DEDICATED`. This is due a bug in the API (See [#1068](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1069)).
+~> **Warning**: This attribute is not supported if your Tier-0 VRF has a class of service `DEDICATED`. This is due to a bug in the API (See [#1068](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1069)).
 - `owner_type` (String, Deprecated) The type of the Edge Gateway owner. Value must be one of : `vdc`, `vdc-group`.
 
  ~> **Attribute deprecated** Remove the `owner_type` attribute configuration, it will be removed in the version [`v0.32.0`](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/20) of the provider. See the [GitHub issue](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/952) for more information.

--- a/docs/resources/edgegateway.md
+++ b/docs/resources/edgegateway.md
@@ -40,10 +40,11 @@ resource "cloudavenue_edgegateway" "example" {
 ### Optional
 
 - `bandwidth` (Number) The bandwidth in `Mbps` of the Edge Gateway. If no value is specified, the bandwidth is automatically calculated based on the remaining bandwidth of the Tier-0 VRF. More information can be found [here](#bandwidth-attribute).
-~> **Warning**: This attribute is not supported if your Tier-0 VRF has a class of service `DEDICATED`. This is due to a bug in the API (See [#1068](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1069)).
-- `owner_type` (String, Deprecated) The type of the Edge Gateway owner. Value must be one of : `vdc`, `vdc-group`. 
+~> **Warning**: This attribute is not supported if your Tier-0 VRF have class of service `DEDICATED`. This is due a bug in the API (See [#1068](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1069)).
+- `owner_type` (String, Deprecated) The type of the Edge Gateway owner. Value must be one of : `vdc`, `vdc-group`.
 
  ~> **Attribute deprecated** Remove the `owner_type` attribute configuration, it will be removed in the version [`v0.32.0`](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/20) of the provider. See the [GitHub issue](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/952) for more information.
+
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
@@ -53,6 +54,7 @@ resource "cloudavenue_edgegateway" "example" {
 - `name` (String) The name of the Edge Gateway.
 
 <a id="nestedatt--timeouts"></a>
+
 ### Nested Schema for `timeouts`
 
 Optional:
@@ -69,12 +71,10 @@ The `bandwidth` attribute is optional. If no value is specified, the bandwidth i
 The following values are supported depending on the service class of the Tier-0 :
 
 <!-- TABLE BANDWIDTH VALUES -->
-* `VRF_DEDICATED_LARGE` {10000, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 2000, 3000, 4000, 5000, 6000]}
-* `VRF_DEDICATED_MEDIUM` {3500, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 2000]}
-* `VRF_PREMIUM` {1000, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000]}
-* `VRF_STANDARD` {300, [5, 25, 50, 75, 100, 150, 200, 250, 300]}
-
-
+- `VRF_DEDICATED_LARGE` {10000, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 2000, 3000, 4000, 5000, 6000]}
+- `VRF_DEDICATED_MEDIUM` {3500, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 2000]}
+- `VRF_PREMIUM` {1000, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000]}
+- `VRF_STANDARD` {300, [5, 25, 50, 75, 100, 150, 200, 250, 300]}
 
 Example with bandwidth:
 
@@ -89,6 +89,7 @@ resource "cloudavenue_edgegateway" "example" {
 ## Import
 
 Import is supported using the following syntax:
+
 ```shell
 # use the name to import the edge gateway
 terraform import cloudavenue_edgegateway.example MyEdgeName

--- a/internal/provider/edgegw/edgegateway_resource.go
+++ b/internal/provider/edgegw/edgegateway_resource.go
@@ -351,8 +351,6 @@ func (r *edgeGatewayResource) Create(ctx context.Context, req resource.CreateReq
 				resp.Diagnostics.AddError("Error waiting for Bandwidth update", err.Error())
 			}
 		}
-
-		// Don't
 	}
 
 	// Use generic read function to refresh the state

--- a/internal/provider/edgegw/edgegateway_resource.go
+++ b/internal/provider/edgegw/edgegateway_resource.go
@@ -351,6 +351,8 @@ func (r *edgeGatewayResource) Create(ctx context.Context, req resource.CreateReq
 				resp.Diagnostics.AddError("Error waiting for Bandwidth update", err.Error())
 			}
 		}
+
+		// Don't
 	}
 
 	// Use generic read function to refresh the state


### PR DESCRIPTION
This pull request addresses a known API bug related to the `bandwidth` attribute for Edge Gateways with Tier-0 VRFs of class `DEDICATED`. The changes introduce a workaround to prevent errors when setting `bandwidth` in these cases and update relevant documentation to clarify the limitation.

### Bug Workaround for `bandwidth` Attribute:
* Added logic in `internal/provider/edgegw/edgegateway_resource.go` to skip `bandwidth` validation and updates when the Tier-0 VRF is of class `DEDICATED`, as the API currently does not support this configuration. This includes updates in the `ModifyPlan` and `Create` methods to handle the limitation gracefully. [[1]](diffhunk://#diff-bae05ffe16d83dbf5c0fdd34caf6ab12fe93c124162d1913e51f47773ddf811bR125-R141) [[2]](diffhunk://#diff-bae05ffe16d83dbf5c0fdd34caf6ab12fe93c124162d1913e51f47773ddf811bL316-R357)

### Documentation Updates:
* Updated `docs/resources/edgegateway.md` and `internal/provider/edgegw/edgegateway_schema.go` to include a warning about the unsupported `bandwidth` attribute for Tier-0 VRFs with class `DEDICATED`. Links to the related GitHub issue were added for further reference. [[1]](diffhunk://#diff-e80eb3f38c4090fdfdc57a16ee010bda5c6f61baeebc67fbf44f254ef886f867R43) [[2]](diffhunk://#diff-4520c2592d2c2ebecc503d71864ba267dda7c89e389cca31ab9a5bdf20f23768L148-R148)

### Changelog Entry:
* Added a release note in `.changelog/1069.txt` to document the workaround for the API bug and clarify that it will be removed once the API is fixed.

### Code Maintenance:
* Minor cleanup in `internal/provider/edgegw/edgegateway_resource.go` to prevent potential panics when the provider is not configured.

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->