### PR TITLE
fix: bugs #1071 #1073 #1064

### DIFF
--- a/.changelog/1064.txt
+++ b/.changelog/1064.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`resource/cloudavenue_edgegateway` - Improved the `cloudavenue_edgegateway` documentation to clarify the usage of the `bandwidth` argument.
+```

--- a/.changelog/1071.txt
+++ b/.changelog/1071.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_edgegateway_network_routed` - Fixed an issue with the cloudavenue_edgegateway_network_routed resource where deletion operations failed due to a BUSY_ENTITY error caused by concurrent gateway updates.
+```

--- a/.changelog/1071.txt
+++ b/.changelog/1071.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-`resource/cloudavenue_edgegateway_network_routed` - Fixed an issue with the cloudavenue_edgegateway_network_routed resource where deletion operations failed due to a BUSY_ENTITY error caused by concurrent gateway updates.
+`resource/cloudavenue_edgegateway_network_routed` - Fixed an issue with the `cloudavenue_edgegateway_network_routed` resource where deletion operations failed due to a `BUSY_ENTITY` error caused by concurrent gateway updates.
 ```

--- a/.changelog/1073.txt
+++ b/.changelog/1073.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-`resource/cloudavenue_edgegateway_network_routed` - Resolved a bug in the cloudavenue_network_routed resource where the static_ip_pool attribute unexpectedly changed from null to an empty set during application.
+`resource/cloudavenue_edgegateway_network_routed` - Resolved a bug in the `cloudavenue_edgegateway_network_routed` resource where the `static_ip_pool` attribute unexpectedly changed from null to an empty set during application.
 ```

--- a/.changelog/1073.txt
+++ b/.changelog/1073.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_edgegateway_network_routed` - Resolved a bug in the cloudavenue_network_routed resource where the static_ip_pool attribute unexpectedly changed from null to an empty set during application.
+```

--- a/cmd/edgegateway-doc/main.go
+++ b/cmd/edgegateway-doc/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	rules := []string{}
 	for _, value := range keys {
-		rules = append(rules, fmt.Sprintf("* `%s` %s\n", value, strings.Trim(strings.ReplaceAll(fmt.Sprint(v1.EdgeGatewayAllowedBandwidth[v1.ClassService(value)]), " ", ", "), "[]")))
+		rules = append(rules, fmt.Sprintf("* `%s`(Max: %dMbps) : %s\n", value, v1.EdgeGatewayAllowedBandwidth[v1.ClassService(value)].T0TotalBandwidth, strings.Trim(strings.ReplaceAll(fmt.Sprint(v1.EdgeGatewayAllowedBandwidth[v1.ClassService(value)].T1AllowedBandwidth), " ", ", "), "[]")))
 	}
 
 	// Generate the content of the file

--- a/docs/resources/edgegateway.md
+++ b/docs/resources/edgegateway.md
@@ -41,10 +41,9 @@ resource "cloudavenue_edgegateway" "example" {
 
 - `bandwidth` (Number) The bandwidth in `Mbps` of the Edge Gateway. If no value is specified, the bandwidth is automatically calculated based on the remaining bandwidth of the Tier-0 VRF. More information can be found [here](#bandwidth-attribute).
 ~> **Warning**: This attribute is not supported if your Tier-0 VRF has a class of service `DEDICATED`. This is due to a bug in the API (See [#1068](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1069)).
-- `owner_type` (String, Deprecated) The type of the Edge Gateway owner. Value must be one of : `vdc`, `vdc-group`.
+- `owner_type` (String, Deprecated) The type of the Edge Gateway owner. Value must be one of : `vdc`, `vdc-group`. 
 
  ~> **Attribute deprecated** Remove the `owner_type` attribute configuration, it will be removed in the version [`v0.32.0`](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/20) of the provider. See the [GitHub issue](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/952) for more information.
-
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only
@@ -54,7 +53,6 @@ resource "cloudavenue_edgegateway" "example" {
 - `name` (String) The name of the Edge Gateway.
 
 <a id="nestedatt--timeouts"></a>
-
 ### Nested Schema for `timeouts`
 
 Optional:
@@ -71,10 +69,12 @@ The `bandwidth` attribute is optional. If no value is specified, the bandwidth i
 The following values are supported depending on the service class of the Tier-0 :
 
 <!-- TABLE BANDWIDTH VALUES -->
-- `VRF_DEDICATED_LARGE` {10000, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 2000, 3000, 4000, 5000, 6000]}
-- `VRF_DEDICATED_MEDIUM` {3500, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 2000]}
-- `VRF_PREMIUM` {1000, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000]}
-- `VRF_STANDARD` {300, [5, 25, 50, 75, 100, 150, 200, 250, 300]}
+* `VRF_DEDICATED_LARGE` {10000, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 2000, 3000, 4000, 5000, 6000]}
+* `VRF_DEDICATED_MEDIUM` {3500, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 2000]}
+* `VRF_PREMIUM` {1000, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000]}
+* `VRF_STANDARD` {300, [5, 25, 50, 75, 100, 150, 200, 250, 300]}
+
+
 
 Example with bandwidth:
 
@@ -89,7 +89,6 @@ resource "cloudavenue_edgegateway" "example" {
 ## Import
 
 Import is supported using the following syntax:
-
 ```shell
 # use the name to import the edge gateway
 terraform import cloudavenue_edgegateway.example MyEdgeName

--- a/docs/resources/edgegateway.md
+++ b/docs/resources/edgegateway.md
@@ -40,7 +40,8 @@ resource "cloudavenue_edgegateway" "example" {
 ### Optional
 
 - `bandwidth` (Number) The bandwidth in `Mbps` of the Edge Gateway. If no value is specified, the bandwidth is automatically calculated based on the remaining bandwidth of the Tier-0 VRF. More information can be found [here](#bandwidth-attribute).
-~> **Warning**: This attribute is not supported if your Tier-0 VRF has a class of service `DEDICATED`. This is due to a bug in the API (See [#1068](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1069)).
+
+!> **Warning** This attribute is not supported if your Tier-0 VRF has a class of service `DEDICATED`. This is due to a bug in the API (See [#1068](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1069)).
 - `owner_type` (String, Deprecated) The type of the Edge Gateway owner. Value must be one of : `vdc`, `vdc-group`. 
 
  ~> **Attribute deprecated** Remove the `owner_type` attribute configuration, it will be removed in the version [`v0.32.0`](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/milestone/20) of the provider. See the [GitHub issue](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/952) for more information.
@@ -69,10 +70,10 @@ The `bandwidth` attribute is optional. If no value is specified, the bandwidth i
 The following values are supported depending on the service class of the Tier-0 :
 
 <!-- TABLE BANDWIDTH VALUES -->
-* `VRF_DEDICATED_LARGE` {10000, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 2000, 3000, 4000, 5000, 6000]}
-* `VRF_DEDICATED_MEDIUM` {3500, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 2000]}
-* `VRF_PREMIUM` {1000, [5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000]}
-* `VRF_STANDARD` {300, [5, 25, 50, 75, 100, 150, 200, 250, 300]}
+* `VRF_DEDICATED_LARGE`(Max: 10000Mbps) : 5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 2000, 3000, 4000, 5000, 6000
+* `VRF_DEDICATED_MEDIUM`(Max: 3500Mbps) : 5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000, 2000
+* `VRF_PREMIUM`(Max: 1000Mbps) : 5, 25, 50, 75, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000
+* `VRF_STANDARD`(Max: 300Mbps) : 5, 25, 50, 75, 100, 150, 200, 250, 300
 
 
 

--- a/internal/provider/edgegw/edgegateway_schema.go
+++ b/internal/provider/edgegw/edgegateway_schema.go
@@ -145,7 +145,7 @@ func edgegwSchema() superschema.Schema {
 				},
 				Resource: &schemaR.Int64Attribute{
 					Optional:            true,
-					MarkdownDescription: "If no value is specified, the bandwidth is automatically calculated based on the remaining bandwidth of the Tier-0 VRF. More information can be found [here](#bandwidth-attribute).\n~> **Warning**: This attribute is not supported if your Tier-0 VRF has a class of service `DEDICATED`. This is due to a bug in the API (See [#1068](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1069))",
+					MarkdownDescription: "If no value is specified, the bandwidth is automatically calculated based on the remaining bandwidth of the Tier-0 VRF. More information can be found [here](#bandwidth-attribute).\n\n!> **Warning** This attribute is not supported if your Tier-0 VRF has a class of service `DEDICATED`. This is due to a bug in the API (See [#1068](https://github.com/orange-cloudavenue/terraform-provider-cloudavenue/issues/1069))",
 				},
 			},
 		},


### PR DESCRIPTION
This pull request addresses several bug fixes and improvements for the `cloudavenue_edgegateway_network_routed` resource, including resolving deletion issues, correcting unexpected attribute changes, and updating the locking mechanism to use a more appropriate identifier. Additionally, minor code cleanups were performed in import statements.

### Bug Fixes:

* **Deletion Failure Fix**: Resolved an issue where deletion operations for the `cloudavenue_edgegateway_network_routed` resource failed due to a `BUSY_ENTITY` error caused by concurrent gateway updates.
* **Static IP Pool Attribute Fix**: Fixed a bug where the `static_ip_pool` attribute unexpectedly changed from `null` to an empty set during application. [[1]](diffhunk://#diff-30cbdbe18e14b3a7ffbc257f62c2a579adc482bb38e796b053ca6107a285a9a6R1-R3) [[2]](diffhunk://#diff-73dddf1dea18bbcfe5b7bd4b72e5bdcb7cc2e7af70f8945917af1e45e79531b8R463-R465) [[3]](diffhunk://#diff-73dddf1dea18bbcfe5b7bd4b72e5bdcb7cc2e7af70f8945917af1e45e79531b8R478)

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->