### PR TITLE
fix: vdcg_network_routed unexpectedly null to empty

### DIFF
--- a/.changelog/1081.txt
+++ b/.changelog/1081.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_vdcg_network_routed` - Resolved a bug in the `cloudavenue_vdcg_network_routed` resource where the `static_ip_pool` attribute unexpectedly changed from null to an empty set during application.
+```


### PR DESCRIPTION
This pull request addresses a bug fix and minor code improvements related to the `cloudavenue_vdcg_network_routed` resource. The most notable change resolves an issue where the `static_ip_pool` attribute was incorrectly set to an empty set instead of null. Additionally, a minor import adjustment was made for better code organization.

### Bug Fix:

* Resolved a bug in the `cloudavenue_vdcg_network_routed` resource where the `static_ip_pool` attribute unexpectedly changed from null to an empty set during application. This was fixed by adding a condition to set `StaticIPPool` to null when no IP ranges are present. (`.changelog/1081.txt` - [[1]](diffhunk://#diff-3aa64b88215c57a582c807a8e8d98dd04d608cd7d6450a6f9cb3636a20f837a5R1-R3) `internal/provider/vdcg/network_routed_resource.go` - [[2]](diffhunk://#diff-a7f8e72aad2cddbd3668449410a071a34b8d16456e9d7b770a692641709bc7caR390-R392)

### Code Improvements:

* Adjusted import statements in `internal/provider/vdcg/network_routed_resource.go` to improve organization by adding a newline between grouped imports. (`internal/provider/vdcg/network_routed_resource.go` - [internal/provider/vdcg/network_routed_resource.goR27](diffhunk://#diff-a7f8e72aad2cddbd3668449410a071a34b8d16456e9d7b770a692641709bc7caR27))