### PR TITLE
fix: devcontainer for devpod

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,21 @@
 ARG VARIANT="1-bullseye"
+
 FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/go:${VARIANT}
 
-COPY .terraformrc /home/vscode/.terraformrc
+ARG USERNAME=cav
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+USER $USERNAME
 
 RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
+COPY .terraformrc /home/cav/.terraformrc
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:${PATH}"
 
 RUN brew install "go-task/tap/go-task"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,11 +26,11 @@
 			]
 		}
 	},
-	"postStartCommand": "task install ; task init",
-	"remoteUser": "vscode",
-	"containerUser": "vscode",
+	"postStartCommand": "echo -e \"CLOUDAVENUE_USER=$CLOUDAVENUE_USER\nCLOUDAVENUE_PASSWORD=$CLOUDAVENUE_PASSWORD\nCLOUDAVENUE_ORG=$CLOUDAVENUE_ORG\nNETBACKUP_USERNAME=$NETBACKUP_USERNAME\nNETBACKUP_PASSWORD=$NETBACKUP_PASSWORD\" > .env ; task install ; task init",
+	"remoteUser": "cav",
+	"containerUser": "cav",
 	"containerEnv": {
-		"HOME": "/home/vscode",
+		"HOME": "/home/cav",
 		// Username
 		"CLOUDAVENUE_USER": "${localEnv:CLOUDAVENUE_USER}",
 		// Password


### PR DESCRIPTION
This pull request updates the `.devcontainer` configuration to improve user management and environment setup. The changes introduce a custom user (`cav`) in the Docker container, modify environment variables and user settings, and update the post-start command to include environment variable initialization.

### User management updates:

* [`.devcontainer/Dockerfile`](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6R2-R18): Added a new user `cav` with custom UID and GID, configured sudo privileges, and set the container to use this user.

### Environment setup improvements:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L29-R33): Updated `postStartCommand` to initialize environment variables in a `.env` file and switched `remoteUser` and `containerUser` from `vscode` to `cav`. Also updated the `HOME` environment variable to match the new user.