### PR TITLE
refactor: TestACC datasource and resource for edgegateway static route

### DIFF
--- a/.changelog/1130.txt
+++ b/.changelog/1130.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+`cloudavenue_edgegateway_static_route`: Improve example documentation to reflect recent changes
+```

--- a/docs/data-sources/edgegateway_static_route.md
+++ b/docs/data-sources/edgegateway_static_route.md
@@ -13,7 +13,7 @@ The `cloudavenue_edgegateway_static_route` data source allows you to retrieve in
 
 ```terraform
 data "cloudavenue_edgegateway_static_route" "example" {
-  edge_gateway_name = "myEdgeName"
+  edge_gateway_name = cloudavenue_edgegateway.example.name
   name              = "example"
 }
 ```

--- a/docs/resources/edgegateway_static_route.md
+++ b/docs/resources/edgegateway_static_route.md
@@ -11,6 +11,24 @@ The `cloudavenue_edgegateway_static_route` resource allows you to create and man
 
 ## Example Usage
 
+Example Simple Usage (Static Route with default next hop)
+```terraform
+resource "cloudavenue_edgegateway_static_route" "example" {
+  name        = "example"
+  description = "example description"
+
+  edge_gateway_id = cloudavenue_edgegateway.example.id
+
+  network_cidr = "192.168.2.0/24"
+  next_hops = [
+    {
+      ip_address = "192.168.2.254"
+    }
+  ]
+}
+```
+
+Example Advanced Usage (Static Route with 2 next hops)
 ```terraform
 resource "cloudavenue_edgegateway_static_route" "example" {
   name        = "example"

--- a/examples/data-sources/cloudavenue_edgegateway_static_route/data-source.tf
+++ b/examples/data-sources/cloudavenue_edgegateway_static_route/data-source.tf
@@ -1,4 +1,4 @@
 data "cloudavenue_edgegateway_static_route" "example" {
-  edge_gateway_name = "myEdgeName"
+  edge_gateway_name = cloudavenue_edgegateway.example.name
   name              = "example"
 }

--- a/examples/resources/cloudavenue_edgegateway_static_route/resource_advanced.tf
+++ b/examples/resources/cloudavenue_edgegateway_static_route/resource_advanced.tf
@@ -8,6 +8,10 @@ resource "cloudavenue_edgegateway_static_route" "example" {
   next_hops = [
     {
       ip_address = "192.168.2.254"
+    },
+    {
+      ip_address     = "192.168.2.253"
+      admin_distance = 2
     }
   ]
 }

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/orange-cloudavenue/cloudavenue-sdk-go v0.26.1
 	github.com/orange-cloudavenue/common-go/print v0.0.0-20250109171729-2be550d5d3ac
 	github.com/orange-cloudavenue/common-go/utils v0.0.0-20240119163616-66b473d92339
+	github.com/orange-cloudavenue/common-go/validators v0.2.2
 	github.com/orange-cloudavenue/terraform-plugin-framework-planmodifiers v1.4.1
 	github.com/orange-cloudavenue/terraform-plugin-framework-superschema v1.11.0
 	github.com/orange-cloudavenue/terraform-plugin-framework-supertypes v1.2.0
@@ -51,6 +52,7 @@ require (
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.8.1 // indirect
 	github.com/cloudflare/circl v1.6.0 // indirect
+	github.com/creasty/defaults v1.8.0 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fbiville/markdown-table-formatter v0.3.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/cloudflare/circl v1.6.0 h1:cr5JKic4HI+LkINy2lg3W2jF8sHCVTBncJr5gIIq7q
 github.com/cloudflare/circl v1.6.0/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creasty/defaults v1.8.0 h1:z27FJxCAa0JKt3utc0sCImAEb+spPucmKoOdLHvHYKk=
+github.com/creasty/defaults v1.8.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -229,6 +231,8 @@ github.com/orange-cloudavenue/common-go/print v0.0.0-20250109171729-2be550d5d3ac
 github.com/orange-cloudavenue/common-go/print v0.0.0-20250109171729-2be550d5d3ac/go.mod h1:IYtCusqpEGS0dhC6F8X9GHrrt1gp1zHaNhSKGYV59Xg=
 github.com/orange-cloudavenue/common-go/utils v0.0.0-20240119163616-66b473d92339 h1:DEKcWLGbEhu/I6kn9NAXhVCFrbPhR+Ef7oLmpLVnnPM=
 github.com/orange-cloudavenue/common-go/utils v0.0.0-20240119163616-66b473d92339/go.mod h1:11JAFfGWVmhoT4AAORKsIC5M6nI+uDGSEOScMzavgPA=
+github.com/orange-cloudavenue/common-go/validators v0.2.2 h1:qu8VGNgdp0aq0SSeM8xWXG2+qd+VbblSDGXh0sdRkKA=
+github.com/orange-cloudavenue/common-go/validators v0.2.2/go.mod h1:Lq2b7ANIy5/sEaWzZNjcCEhvDzkUL1fo4e4IK0txKt0=
 github.com/orange-cloudavenue/terraform-plugin-framework-planmodifiers v1.4.1 h1:eU6rJu+6Nrjd5h/swpeaZOk5ndKdlhRUhb4czwiBq9Q=
 github.com/orange-cloudavenue/terraform-plugin-framework-planmodifiers v1.4.1/go.mod h1:P6xBWALTxSvFCPejfnWwP0xAgeVVqkAIPvKHSEbLgYU=
 github.com/orange-cloudavenue/terraform-plugin-framework-superschema v1.11.0 h1:uezhiY+wp4khq2i9z2jbr26e816BQYKFolCjsZlLIzU=

--- a/internal/testsacc/acctest_datasources_test.go
+++ b/internal/testsacc/acctest_datasources_test.go
@@ -55,6 +55,7 @@ func GetDataSourceConfig() map[testsacc.ResourceName]func() *testsacc.ResourceCo
 		EdgeGatewayNetworkRoutedDataSourceName:  testsacc.NewResourceConfig(NewEdgeGatewayNetworkRoutedDataSourceTest()),
 		EdgeGatewayServicesDataSourceName:       testsacc.NewResourceConfig(NewEdgeGatewayServicesDataSourceTest()),
 		EdgeGatewayVPNIPSecDataSourceName:       testsacc.NewResourceConfig(NewEdgeGatewayVPNIPSecDataSourceTest()),
+		EdgeGatewayStaticRouteDataSourceName:    testsacc.NewResourceConfig(NewEdgeGatewayStaticRouteDataSourceTest()),
 
 		// * EdgeGateway LoadBalancer (elb)
 		ELBPoolDataSourceName:                 testsacc.NewResourceConfig(NewELBPoolDataSourceTest()),

--- a/internal/testsacc/acctest_resources_test.go
+++ b/internal/testsacc/acctest_resources_test.go
@@ -51,6 +51,7 @@ func GetResourceConfig() map[testsacc.ResourceName]func() *testsacc.ResourceConf
 		EdgeGatewayNetworkRoutedResourceName:  testsacc.NewResourceConfig(NewEdgeGatewayNetworkRoutedResourceTest()),
 		EdgeGatewayServicesResourceName:       testsacc.NewResourceConfig(NewEdgeGatewayServicesResourceTest()),
 		EdgeGatewayVPNIPSecResourceName:       testsacc.NewResourceConfig(NewEdgeGatewayVPNIPSecResourceTest()),
+		EdgeGatewayStaticRouteResourceName:    testsacc.NewResourceConfig(NewEdgeGatewayStaticRouteResourceTest()),
 
 		// * EdgeGateway LoadBalancer (elb)
 		ELBPoolResourceName:                 testsacc.NewResourceConfig(NewELBPoolResourceTest()),

--- a/internal/testsacc/edgegw_edgegateway_resource_test.go
+++ b/internal/testsacc/edgegw_edgegateway_resource_test.go
@@ -23,24 +23,6 @@ import (
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/edgegw"
 )
 
-const testAccEdgeGatewayResourceConfig = `
-data "cloudavenue_tier0_vrfs" "example_with_vdc" {}
-
-resource "cloudavenue_edgegateway" "example_with_vdc" {
-  owner_name     = "MyEdgeGateway"
-  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example_with_vdc.names.0
-}
-`
-
-const testAccEdgeGatewayGroupResourceConfig = `
-data "cloudavenue_tier0_vrfs" "example_with_group" {}
-
-resource "cloudavenue_edgegateway" "example_with_group" {
-  owner_name     = "MyEdgeGatewayGroup"
-  tier0_vrf_name = data.cloudavenue_tier0_vrfs.example_with_group.names.0
-}
-`
-
 var _ testsacc.TestACC = &EdgeGatewayResource{}
 
 const (

--- a/internal/testsacc/edgegw_static_route_datasource_test.go
+++ b/internal/testsacc/edgegw_static_route_datasource_test.go
@@ -10,31 +10,61 @@
 package testsacc
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/testsacc"
 )
 
-const testAccStaticRouteDataSourceConfig = `
-data "cloudavenue_edgegateway_static_route" "example" {
-	edge_gateway_id = cloudavenue_edgegateway.example_with_vdc.id
-	name = cloudavenue_edgegateway_static_route.example.name
+var _ testsacc.TestACC = &EdgeGatewayStaticRouteDataSource{}
+
+const (
+	EdgeGatewayStaticRouteDataSourceName = testsacc.ResourceName("data.cloudavenue_edgegateway_static_route")
+)
+
+type EdgeGatewayStaticRouteDataSource struct{}
+
+func NewEdgeGatewayStaticRouteDataSourceTest() testsacc.TestACC {
+	return &EdgeGatewayStaticRouteDataSource{}
 }
-`
 
-func TestAccStaticRouteDataSource(t *testing.T) {
-	dataSourceName := "data.cloudavenue_edgegateway_static_route.example"
+func (r *EdgeGatewayStaticRouteDataSource) GetResourceName() string {
+	return EdgeGatewayStaticRouteDataSourceName.String()
+}
 
+func (r *EdgeGatewayStaticRouteDataSource) DependenciesConfig() (resp testsacc.DependenciesConfigResponse) {
+	resp.Append(GetResourceConfig()[EdgeGatewayStaticRouteResourceName]().GetDefaultConfig)
+	return
+}
+
+func (r *EdgeGatewayStaticRouteDataSource) Tests(_ context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
+	return map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test{
+		"basic": func(_ context.Context, _ string) testsacc.Test {
+			return testsacc.Test{
+				Create: testsacc.TFConfig{
+					TFConfig: `
+					data "cloudavenue_edgegateway_static_route" "example" {
+					  edge_gateway_id = cloudavenue_edgegateway.example_with_vdc.id
+					  name = cloudavenue_edgegateway_static_route.example.name
+					}
+					`,
+					Checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttrSet("data.cloudavenue_edgegateway_static_route.example", "id"),
+						resource.TestCheckResourceAttrSet("data.cloudavenue_edgegateway_static_route.example", "network"),
+						resource.TestCheckResourceAttrSet("data.cloudavenue_edgegateway_static_route.example", "next_hop"),
+					},
+				},
+			}
+		},
+	}
+}
+
+func TestAccEdgeGatewayStaticRouteDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Read testing
-			{
-				// Apply test
-				Config: ConcatTests(testAccEdgeGatewayResourceConfig, testAccStaticRouteResourceConfig, testAccStaticRouteDataSourceConfig),
-				Check:  staticRouteTestCheck(dataSourceName),
-			},
-		},
+		Steps:                    testsacc.GenerateTests(&EdgeGatewayStaticRouteDataSource{}),
 	})
 }

--- a/internal/testsacc/edgegw_static_route_datasource_test.go
+++ b/internal/testsacc/edgegw_static_route_datasource_test.go
@@ -41,20 +41,15 @@ func (r *EdgeGatewayStaticRouteDataSource) DependenciesConfig() (resp testsacc.D
 
 func (r *EdgeGatewayStaticRouteDataSource) Tests(_ context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
 	return map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test{
-		"basic": func(_ context.Context, _ string) testsacc.Test {
+		"example": func(_ context.Context, _ string) testsacc.Test {
 			return testsacc.Test{
 				Create: testsacc.TFConfig{
 					TFConfig: `
 					data "cloudavenue_edgegateway_static_route" "example" {
-					  edge_gateway_id = cloudavenue_edgegateway.example_with_vdc.id
+					  edge_gateway_id = cloudavenue_edgegateway.example.id
 					  name = cloudavenue_edgegateway_static_route.example.name
-					}
-					`,
-					Checks: []resource.TestCheckFunc{
-						resource.TestCheckResourceAttrSet("data.cloudavenue_edgegateway_static_route.example", "id"),
-						resource.TestCheckResourceAttrSet("data.cloudavenue_edgegateway_static_route.example", "network"),
-						resource.TestCheckResourceAttrSet("data.cloudavenue_edgegateway_static_route.example", "next_hop"),
-					},
+					}`,
+					Checks: GetResourceConfig()[EdgeGatewayStaticRouteResourceName]().GetDefaultChecks(),
 				},
 			}
 		},

--- a/internal/testsacc/edgegw_static_route_resource_test.go
+++ b/internal/testsacc/edgegw_static_route_resource_test.go
@@ -10,181 +10,158 @@
 package testsacc
 
 import (
-	"fmt"
+	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/testsacc"
 )
 
-const testAccStaticRouteResourceConfig = `
-resource "cloudavenue_edgegateway_static_route" "example" {
-	edge_gateway_id = cloudavenue_edgegateway.example_with_vdc.id
-	name = "example"
-	network_cidr = "192.168.1.0/24"
-	next_hops = [
-		{
-			ip_address = "192.168.1.254"
-		}
-	]
-}
-`
+var _ testsacc.TestACC = &EdgeGatewayStaticRouteResource{}
 
-const testAccStaticRouteResourceConfigUpdate = `
-resource "cloudavenue_edgegateway_static_route" "example" {
-	edge_gateway_id = cloudavenue_edgegateway.example_with_vdc.id
-	name = "example"
-	description = "example description"
-	network_cidr = "192.168.2.0/24"
-	next_hops = [
-		{
-			ip_address = "192.168.2.254"
+const EdgeGatewayStaticRouteResourceName = testsacc.ResourceName("cloudavenue_edgegateway_static_route")
+
+type EdgeGatewayStaticRouteResource struct{}
+
+func NewEdgeGatewayStaticRouteResourceTest() testsacc.TestACC {
+	return &EdgeGatewayStaticRouteResource{}
+}
+
+func (r *EdgeGatewayStaticRouteResource) GetResourceName() string {
+	return EdgeGatewayStaticRouteResourceName.String()
+}
+
+func (r *EdgeGatewayStaticRouteResource) DependenciesConfig() (resp testsacc.DependenciesConfigResponse) {
+	resp.Append(GetResourceConfig()[EdgeGatewayResourceName]().GetDefaultConfig)
+	return
+}
+
+func (r *EdgeGatewayStaticRouteResource) Tests(_ context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
+	return map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test{
+		"example": func(_ context.Context, resourceName string) testsacc.Test {
+			return testsacc.Test{
+				CommonChecks: []resource.TestCheckFunc{
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrWith(resourceName, "edge_gateway_id", urn.TestIsType(urn.Gateway)),
+				},
+				Create: testsacc.TFConfig{
+					TFConfig: testsacc.GenerateFromTemplate(resourceName, `
+		resource "cloudavenue_edgegateway_static_route" "example" {
+		  edge_gateway_id = cloudavenue_edgegateway.example.id
+		  name = {{ generate . "name" }}
+		  network_cidr = "192.168.1.0/24"
+		  next_hops = [
+		{ ip_address = "192.168.1.254" }
+		  ]
+		}`),
+					Checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceName, "name", testsacc.GetValueFromTemplate(resourceName, "name")),
+						resource.TestCheckNoResourceAttr(resourceName, "description"),
+						resource.TestCheckResourceAttr(resourceName, "network_cidr", "192.168.1.0/24"),
+						resource.TestCheckResourceAttr(resourceName, "next_hops.#", "1"),
+						resource.TestCheckResourceAttr(resourceName, "next_hops.0.ip_address", "192.168.1.254"),
+						resource.TestCheckResourceAttr(resourceName, "next_hops.0.admin_distance", "1"),
+					},
+				},
+				Updates: []testsacc.TFConfig{
+					{
+						TFConfig: testsacc.GenerateFromTemplate(resourceName, `
+		resource "cloudavenue_edgegateway_static_route" "example" {
+		  edge_gateway_id = cloudavenue_edgegateway.example.id
+		  name = {{ generate . "name" }}
+		  description = {{ generate . "description" }}
+		  network_cidr = "192.168.2.0/24"
+		  next_hops = [
+		{ ip_address = "192.168.2.254" },
+		{ ip_address = "192.168.2.253", admin_distance = 2 }
+		  ]
+		}`),
+						Checks: []resource.TestCheckFunc{
+							resource.TestCheckResourceAttr(resourceName, "name", testsacc.GetValueFromTemplate(resourceName, "name")),
+							resource.TestCheckResourceAttr(resourceName, "description", testsacc.GetValueFromTemplate(resourceName, "description")),
+							resource.TestCheckResourceAttr(resourceName, "network_cidr", "192.168.2.0/24"),
+							resource.TestCheckResourceAttr(resourceName, "next_hops.#", "2"),
+							resource.TestCheckResourceAttr(resourceName, "next_hops.0.ip_address", "192.168.2.254"),
+							resource.TestCheckResourceAttr(resourceName, "next_hops.0.admin_distance", "1"),
+							resource.TestCheckResourceAttr(resourceName, "next_hops.1.ip_address", "192.168.2.253"),
+							resource.TestCheckResourceAttr(resourceName, "next_hops.1.admin_distance", "2"),
+						},
+					},
+				},
+				Imports: []testsacc.TFImport{
+					{ImportStateIDBuilder: []string{"edge_gateway_id", "id"}, ImportState: true, ImportStateVerify: true},
+				},
+				Destroy: true,
+			}
 		},
-		{
-			ip_address = "192.168.2.253"
-			admin_distance = 2
-		}
-	]
-}
-`
-
-const testAccStaticRouteResourceConfigWithVDCGroup = `
-resource "cloudavenue_edgegateway_static_route" "example" {
-	edge_gateway_id = cloudavenue_edgegateway.example_with_group.id
-	name = "example"
-	network_cidr = "192.168.1.0/24"
-	next_hops = [
-		{
-			ip_address = "192.168.1.254"
-		}
-	]
-}
-`
-
-const testAccStaticRouteResourceConfigUpdateWithVDCGroup = `
-resource "cloudavenue_edgegateway_static_route" "example" {
-	edge_gateway_id = cloudavenue_edgegateway.example_with_group.id
-	name = "example"
-	description = "example description"
-	network_cidr = "192.168.2.0/24"
-	next_hops = [
-		{
-			ip_address = "192.168.2.254"
+		"example_with_vdc_group": func(_ context.Context, resourceName string) testsacc.Test {
+			return testsacc.Test{
+				CommonDependencies: func() (resp testsacc.DependenciesConfigResponse) {
+					resp.Append(GetResourceConfig()[EdgeGatewayResourceName]().GetSpecificConfig("example_with_vdc_group"))
+					return
+				},
+				CommonChecks: []resource.TestCheckFunc{
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrWith(resourceName, "edge_gateway_id", urn.TestIsType(urn.Gateway)),
+				},
+				Create: testsacc.TFConfig{
+					TFConfig: testsacc.GenerateFromTemplate(resourceName, `
+					resource "cloudavenue_edgegateway_static_route" "example_with_vdc_group" {
+					  edge_gateway_id = cloudavenue_edgegateway.example_with_vdc_group.id
+					  name = {{ generate . "name" }}
+					  network_cidr = "192.168.1.0/24"
+					  next_hops = [
+					    { ip_address = "192.168.1.254" }
+					  ]
+					}`),
+					Checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr(resourceName, "name", testsacc.GetValueFromTemplate(resourceName, "name")),
+						resource.TestCheckNoResourceAttr(resourceName, "description"),
+						resource.TestCheckResourceAttr(resourceName, "network_cidr", "192.168.1.0/24"),
+						resource.TestCheckResourceAttr(resourceName, "next_hops.#", "1"),
+						resource.TestCheckResourceAttr(resourceName, "next_hops.0.ip_address", "192.168.1.254"),
+						resource.TestCheckResourceAttr(resourceName, "next_hops.0.admin_distance", "1"),
+					},
+				},
+				Updates: []testsacc.TFConfig{
+					{
+						TFConfig: testsacc.GenerateFromTemplate(resourceName, `
+							resource "cloudavenue_edgegateway_static_route" "example_with_vdc_group" {
+							  edge_gateway_id = cloudavenue_edgegateway.example_with_vdc_group.id
+							  name = {{ generate . "name" }}
+							  description = {{ generate . "description" }}
+							  network_cidr = "192.168.2.0/24"
+							  next_hops = [
+							    { ip_address = "192.168.2.254" },
+							    { ip_address = "192.168.2.253", admin_distance = 2 }
+							  ]
+							}`),
+						Checks: []resource.TestCheckFunc{
+							resource.TestCheckResourceAttr(resourceName, "name", testsacc.GetValueFromTemplate(resourceName, "name")),
+							resource.TestCheckResourceAttr(resourceName, "description", testsacc.GetValueFromTemplate(resourceName, "description")),
+							resource.TestCheckResourceAttr(resourceName, "network_cidr", "192.168.2.0/24"),
+							resource.TestCheckResourceAttr(resourceName, "next_hops.#", "2"),
+							resource.TestCheckResourceAttr(resourceName, "next_hops.0.ip_address", "192.168.2.254"),
+							resource.TestCheckResourceAttr(resourceName, "next_hops.0.admin_distance", "1"),
+							resource.TestCheckResourceAttr(resourceName, "next_hops.1.ip_address", "192.168.2.253"),
+							resource.TestCheckResourceAttr(resourceName, "next_hops.1.admin_distance", "2"),
+						},
+					},
+				},
+				Imports: []testsacc.TFImport{
+					{ImportStateIDBuilder: []string{"edge_gateway_name", "name"}, ImportState: true, ImportStateVerify: true},
+				},
+			}
 		},
-		{
-			ip_address = "192.168.2.253"
-			admin_distance = 2
-		}
-	]
-}
-`
-
-func staticRouteTestCheck(resourceName string) resource.TestCheckFunc {
-	return resource.ComposeAggregateTestCheckFunc(
-		resource.TestCheckResourceAttrSet(resourceName, "id"),
-		resource.TestCheckResourceAttrWith(resourceName, "edge_gateway_id", urn.TestIsType(urn.Gateway)),
-		resource.TestCheckResourceAttr(resourceName, "name", "example"),
-		resource.TestCheckNoResourceAttr(resourceName, "description"),
-		resource.TestCheckResourceAttr(resourceName, "network_cidr", "192.168.1.0/24"),
-		resource.TestCheckResourceAttr(resourceName, "next_hops.#", "1"),
-		resource.TestCheckResourceAttr(resourceName, "next_hops.0.ip_address", "192.168.1.254"),
-		resource.TestCheckResourceAttr(resourceName, "next_hops.0.admin_distance", "1"),
-	)
+	}
 }
 
-func staticRouteTestCheckUpdated(resourceName string) resource.TestCheckFunc {
-	return resource.ComposeAggregateTestCheckFunc(
-		resource.TestCheckResourceAttrSet(resourceName, "id"),
-		resource.TestCheckResourceAttrWith(resourceName, "edge_gateway_id", urn.TestIsType(urn.Gateway)),
-		resource.TestCheckResourceAttr(resourceName, "name", "example"),
-		resource.TestCheckResourceAttr(resourceName, "description", "example description"),
-		resource.TestCheckResourceAttr(resourceName, "network_cidr", "192.168.2.0/24"),
-		resource.TestCheckResourceAttr(resourceName, "next_hops.#", "2"),
-		resource.TestCheckResourceAttr(resourceName, "next_hops.0.ip_address", "192.168.2.254"),
-		resource.TestCheckResourceAttr(resourceName, "next_hops.0.admin_distance", "1"),
-		resource.TestCheckResourceAttr(resourceName, "next_hops.1.ip_address", "192.168.2.253"),
-		resource.TestCheckResourceAttr(resourceName, "next_hops.1.admin_distance", "2"),
-	)
-}
-
-func TestAccStaticRouteResource(t *testing.T) {
-	resourceName := "cloudavenue_edgegateway_static_route.example"
-
+func TestAccEdgeGatewayStaticRouteResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// * Test with VDC
-			// Read testing
-			{
-				// Apply test
-				Config: ConcatTests(testAccEdgeGatewayResourceConfig, testAccStaticRouteResourceConfig),
-				Check:  staticRouteTestCheck(resourceName),
-			},
-			// Update testing
-			{
-				// Update test
-				Config: ConcatTests(testAccEdgeGatewayResourceConfig, testAccStaticRouteResourceConfigUpdate),
-				Check:  staticRouteTestCheckUpdated(resourceName),
-			},
-			// Import State testing
-			{
-				// Import test
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testAccStaticRouteResourceImportStateIDFuncWithID(resourceName),
-			},
-			{
-				// Delete test
-				Destroy: true,
-				Config:  ConcatTests(testAccEdgeGatewayResourceConfig, testAccStaticRouteResourceConfigUpdate),
-			},
-
-			// * Test with VDCGroup
-			{
-				// Apply test
-				Config: ConcatTests(testAccEdgeGatewayGroupResourceConfig, testAccStaticRouteResourceConfigWithVDCGroup),
-				Check:  staticRouteTestCheck(resourceName),
-			},
-			// Update testing
-			{
-				// Update test
-				Config: ConcatTests(testAccEdgeGatewayGroupResourceConfig, testAccStaticRouteResourceConfigUpdateWithVDCGroup),
-				Check:  staticRouteTestCheckUpdated(resourceName),
-			},
-			// Import State testing
-			{
-				// Import test
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: testAccStaticRouteResourceImportStateIDFuncWithName(resourceName),
-			},
-		},
+		Steps:                    testsacc.GenerateTests(&EdgeGatewayStaticRouteResource{}),
 	})
-}
-
-func testAccStaticRouteResourceImportStateIDFuncWithID(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		return fmt.Sprintf("%s.%s", rs.Primary.Attributes["edge_gateway_id"], rs.Primary.Attributes["id"]), nil
-	}
-}
-
-func testAccStaticRouteResourceImportStateIDFuncWithName(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmt.Errorf("Not found: %s", resourceName)
-		}
-
-		return fmt.Sprintf("%s.%s", rs.Primary.Attributes["edge_gateway_name"], rs.Primary.Attributes["name"]), nil
-	}
 }

--- a/internal/testsacc/edgegw_static_route_resource_test.go
+++ b/internal/testsacc/edgegw_static_route_resource_test.go
@@ -43,7 +43,9 @@ func (r *EdgeGatewayStaticRouteResource) Tests(_ context.Context) map[testsacc.T
 		"example": func(_ context.Context, resourceName string) testsacc.Test {
 			return testsacc.Test{
 				CommonChecks: []resource.TestCheckFunc{
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					// Check that the resource has been created and has an ID formatted as uuid v4
+					resource.TestCheckResourceAttrWith(resourceName, "id", ToValidate("uuid4")),
+					// Check that the edge_gateway_id is a valid urn of type Gateway
 					resource.TestCheckResourceAttrWith(resourceName, "edge_gateway_id", urn.TestIsType(urn.Gateway)),
 				},
 				Create: testsacc.TFConfig{
@@ -103,7 +105,7 @@ func (r *EdgeGatewayStaticRouteResource) Tests(_ context.Context) map[testsacc.T
 					return
 				},
 				CommonChecks: []resource.TestCheckFunc{
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrWith(resourceName, "id", ToValidate("uuid4")),
 					resource.TestCheckResourceAttrWith(resourceName, "edge_gateway_id", urn.TestIsType(urn.Gateway)),
 				},
 				Create: testsacc.TFConfig{

--- a/internal/testsacc/helpers.go
+++ b/internal/testsacc/helpers.go
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package testsacc
+
+import (
+	"fmt"
+
+	"github.com/orange-cloudavenue/common-go/validators"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// ToValidate returns a CheckResourceAttrWithFunc that validates a string using the given validator name.
+// If the value is empty, an error is returned indicating the value is not valid for the validator.
+// Otherwise, the value is validated using the provided validator name via validators.New().Var().
+func ToValidate(validatorToCheck string) resource.CheckResourceAttrWithFunc {
+	return func(value string) error {
+		if value == "" {
+			return fmt.Errorf("empty value, is not a valid %s", validatorToCheck)
+		}
+
+		return validators.New().Var(value, validatorToCheck)
+	}
+}

--- a/internal/testsacc/helpers_test.go
+++ b/internal/testsacc/helpers_test.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+// SPDX-License-Identifier: Mozilla Public License 2.0
+//
+// This software is distributed under the MPL-2.0 license.
+// the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+// or see the "LICENSE" file for more details.
+
+package testsacc
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestToValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		validator string
+		wantErr   bool
+	}{
+		// uuid4
+		{"valid uuid v4", uuid.New().String(), "uuid4", false},
+		{"empty string", "", "uuid4", true},
+		{"invalid uuid (wrong version)", func() string {
+			v, _ := uuid.NewV7()
+			return v.String()
+		}(), "uuid4", true},
+		{"invalid uuid (not uuid)", "not-a-uuid", "uuid4", true},
+		{"invalid uuid (v4 but wrong chars)", "zzzzzzzz-zzzz-4zzz-8zzz-zzzzzzzzzzzz", "uuid4", true},
+		// email
+		{"valid email", "test@example.com", "email", false},
+		{"invalid email", "not-an-email", "email", true},
+		// urn
+		{"valid urn", "urn:example:resource", "urn_rfc2141", false},
+		{"invalid urn", "not-a-urn", "urn_rfc2141", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ToValidate(tt.validator)(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ToValidate(%q) error = %v, wantErr %v", tt.validator, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/templates/resources/edgegateway_static_route.md.tmpl
+++ b/templates/resources/edgegateway_static_route.md.tmpl
@@ -12,8 +12,12 @@ description: |-
 {{ if .HasExample -}}
 ## Example Usage
 
+Example Simple Usage (Static Route with default next hop)
 {{ tffile .ExampleFile }}
 {{- end }}
+
+Example Advanced Usage (Static Route with 2 next hops)
+{{ tffile (printf "examples/resources/%s/resource_advanced.tf" .Name)}}
 
 {{ .SchemaMarkdown | trimspace }}
 


### PR DESCRIPTION
### Documentation Enhancements:
* Updated IPsec VPN Tunnel examples to use dynamic references like `cloudavenue_publicip.example.public_ip` for local IP addresses. [[1]](diffhunk://#diff-1d913c53bb2efe513889e55aa2c9559db9fc7552cf1340abc3832b1cf2a2ad2aL24-R34) [[2]](diffhunk://#diff-1d913c53bb2efe513889e55aa2c9559db9fc7552cf1340abc3832b1cf2a2ad2aL43-R47)

### Resource and Data Source Examples:
* Added new example configurations for `cloudavenue_edgegateway_static_route` with advanced next-hop setups.

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
--- PASS: TestAccEdgeGatewayStaticRouteResource (868.66s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  869.156s

--- PASS: TestAccEdgeGatewayStaticRouteDataSource (351.45s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  351.936s
```