### PR TITLE
chore: Now VDC parameter for provider is deprecated

### DIFF
--- a/.changelog/1119.txt
+++ b/.changelog/1119.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+`provider` - The attribute `vdc` in the configuration provider is deprecated and will be removed in the release `v0.39.0`. Please adjust your configuration. Warning the environment variable`CLOUDAVENUE_VDC` is also deprecated.
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,9 @@ Documentation regarding data sources and resources can be found in the left side
 
  -> Note : If you need more information about Cloud Avenue, please visit [Cloud Avenue documentation](https://wiki.cloudavenue.orange-business.com/wiki/Services_catalogue).
 
+  !> [DEPRECATED] (Breaking Change Upcoming): The 'vdc' field is now deprecated (since `v0.34.0`) and will be removed in `v0.39.0`.
+
+
 ## Authentication and Configuration
 
 Configuration for the CloudAvenue Provider can be derived from several sources, which are applied in the following order:
@@ -26,11 +29,12 @@ Configuration for the CloudAvenue Provider can be derived from several sources, 
 
 ### cloudavenue configuration
 
+  !> [DEPRECATED] (Breaking Change Upcoming): The 'vdc' configuration field is now deprecated (since `v0.34.0`) and will be removed in `v0.39.0`.
+
 * `org` (String) The organization used on Cloud Avenue.
 * `user` (String) The username to use to connect to the Cloud Avenue.
 * `password` (String, Sensitive) The password to use to connect to the Cloud Avenue.
-  -> [DEPRECATED] The 'vdc' field is deprecated since v0.34.0 and will be removed in v0.39.0.
-* `vdc` (String) The VDC used on Cloud Avenue. If this field is set, we will use by default this VDC for all resources. If your set a custom VDC for a resource, this field will be ignored.
+* `vdc` (String) (deprecated) The VDC used on Cloud Avenue. If this field is set, we will use by default this VDC for all resources. If you set a custom VDC for a resource, this field will be ignored.
 * `url` (String) The URL of the Cloud Avenue. This field is computed by default. If you want to use a custom URL, you can set this field.
 
 ### Netbackup configuration
@@ -59,6 +63,8 @@ Other settings related to [Schema](#schema) can be configured.
 
 ## Environment Variables
 
+ !> [DEPRECATED] (Breaking Change Upcoming): The 'vdc' variable is now deprecated (since `v0.34.0`) and will be removed in `v0.39.0`.
+
 Credentials can be provided by using the environment variables related to [List of Environment Variables](#list-of-environment-variables).
 It's recommended to use environment variables to avoid hard-coding credentials in any Terraform configuration and risks secret leakage should this file ever be committed to a public version control system.
 
@@ -81,7 +87,7 @@ export CLOUDAVENUE_PASSWORD="my-password"
 | `org` | `CLOUDAVENUE_ORG` |
 | `user` | `CLOUDAVENUE_USERNAME` |
 | `password` | `CLOUDAVENUE_PASSWORD` |
-| `vdc` | `CLOUDAVENUE_VDC` |
+| `vdc` | `CLOUDAVENUE_VDC` (deprecated) |
 | `url` | `CLOUDAVENUE_URL` |
 | `netbackup_user` | `NETBACKUP_USERNAME` |
 | `netbackup_password` | `NETBACKUP_PASSWORD` |

--- a/internal/provider/provider_schema.go
+++ b/internal/provider/provider_schema.go
@@ -49,7 +49,7 @@ func providerSchema(_ context.Context) schema.Schema {
 			"vdc": schema.StringAttribute{
 				MarkdownDescription: "The VDC used on Cloud Avenue API. Can also be set with the `CLOUDAVENUE_VDC` environment variable.",
 				Optional:            true,
-				DeprecationMessage:  "[DEPRECATED] The 'vdc' field is deprecated since v0.34.0 and will be removed in v0.39.0.",
+				DeprecationMessage:  "[DEPRECATED] (Breaking Change Upcoming): The `vdc` field for provider configuration and variable are now deprecated (since `v0.34.0`) and will be removed in `v0.39.0` (ref: https://registry.terraform.io/providers/orange-cloudavenue/cloudavenue/latest/docs). ",
 			},
 			"netbackup_url": schema.StringAttribute{
 				MarkdownDescription: "The URL of the NetBackup API. Can also be set with the `NETBACKUP_URL` environment variable.",

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -13,6 +13,9 @@ Documentation regarding data sources and resources can be found in the left side
 
  -> Note : If you need more information about Cloud Avenue, please visit [Cloud Avenue documentation](https://wiki.cloudavenue.orange-business.com/wiki/Services_catalogue).
 
+  !> [DEPRECATED] (Breaking Change Upcoming): The 'vdc' field is now deprecated (since `v0.34.0`) and will be removed in `v0.39.0`.
+
+
 ## Authentication and Configuration
 
 Configuration for the CloudAvenue Provider can be derived from several sources, which are applied in the following order:
@@ -26,11 +29,12 @@ Configuration for the CloudAvenue Provider can be derived from several sources, 
 
 ### cloudavenue configuration
 
+  !> [DEPRECATED] (Breaking Change Upcoming): The 'vdc' configuration field is now deprecated (since `v0.34.0`) and will be removed in `v0.39.0`.
+
 * `org` (String) The organization used on Cloud Avenue.
 * `user` (String) The username to use to connect to the Cloud Avenue.
 * `password` (String, Sensitive) The password to use to connect to the Cloud Avenue.
-  -> [DEPRECATED] The 'vdc' field is deprecated since v0.34.0 and will be removed in v0.39.0.
-* `vdc` (String) The VDC used on Cloud Avenue. If this field is set, we will use by default this VDC for all resources. If your set a custom VDC for a resource, this field will be ignored.
+* `vdc` (String) (deprecated) The VDC used on Cloud Avenue. If this field is set, we will use by default this VDC for all resources. If you set a custom VDC for a resource, this field will be ignored.
 * `url` (String) The URL of the Cloud Avenue. This field is computed by default. If you want to use a custom URL, you can set this field.
 
 ### Netbackup configuration
@@ -59,6 +63,8 @@ Other settings related to [Schema](#schema) can be configured.
 
 ## Environment Variables
 
+ !> [DEPRECATED] (Breaking Change Upcoming): The 'vdc' variable is now deprecated (since `v0.34.0`) and will be removed in `v0.39.0`.
+
 Credentials can be provided by using the environment variables related to [List of Environment Variables](#list-of-environment-variables).
 It's recommended to use environment variables to avoid hard-coding credentials in any Terraform configuration and risks secret leakage should this file ever be committed to a public version control system.
 
@@ -81,7 +87,7 @@ export CLOUDAVENUE_PASSWORD="my-password"
 | `org` | `CLOUDAVENUE_ORG` |
 | `user` | `CLOUDAVENUE_USERNAME` |
 | `password` | `CLOUDAVENUE_PASSWORD` |
-| `vdc` | `CLOUDAVENUE_VDC` |
+| `vdc` | `CLOUDAVENUE_VDC` (deprecated) |
 | `url` | `CLOUDAVENUE_URL` |
 | `netbackup_user` | `NETBACKUP_USERNAME` |
 | `netbackup_password` | `NETBACKUP_PASSWORD` |


### PR DESCRIPTION
This pull request introduces breaking changes to the CloudAvenue provider by deprecating the `vdc` attribute in the provider configuration and its associated environment variable (`CLOUDAVENUE_VDC`). The deprecation was announced in version `v0.34.0`, and the attribute will be removed in version `v0.39.0`. Documentation and code updates have been made to reflect this change.

### Breaking Changes

* [`.changelog/1119.txt`](diffhunk://#diff-3799e728563d57785478aa33362fdfd32ebdc9823ee1ef42de8990ebf6e042e8R1-R3): Added a release note specifying the deprecation of the `vdc` attribute and its removal in `v0.39.0`.
* [`internal/provider/provider_schema.go`](diffhunk://#diff-d4d1213314b4555976d29d47a275edf65f9f78c215c642e7650ae785ee1e5df0R52): Updated the provider schema to include a deprecation message for the `vdc` attribute.

### Documentation Updates

* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R16-R18): Added deprecation warnings for the `vdc` field in various sections, including configuration, environment variables, and the associated environment variable table. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R16-R18) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R32-R37) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R66-R67) [[4]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L83-R90)
* [`templates/index.md.tmpl`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R16-R18): Updated template documentation to include deprecation warnings for the `vdc` field in configuration, environment variables, and the associated environment variable table. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R16-R18) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R32-R37) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R66-R67) [[4]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L83-R90)