### PR TITLE
fix: bug update `_elb_virtual_service` ress if service engine is set

### DIFF
--- a/.changelog/1142.txt
+++ b/.changelog/1142.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_elb_virtual_service` - Fix bug where `service_engine_group_name` is not retrieved correctly if attribute is set. 
+```

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,7 +87,7 @@ linters:
           disabled: false
         - name: var-naming
           arguments:
-            - []
+            - [] 
             - - ACL
               - API
               - ASCII
@@ -137,6 +137,7 @@ linters:
               - BMS
               - SAML
               - VDCG
+            - - skip-package-name-checks: true
           severity: warning
           disabled: false
   exclusions:

--- a/internal/provider/elb/virtual_service_schema.go
+++ b/internal/provider/elb/virtual_service_schema.go
@@ -67,6 +67,7 @@ func virtualServiceSchema(_ context.Context) superschema.Schema {
 					Computed:            true,
 					PlanModifiers: []planmodifier.String{
 						stringplanmodifier.RequiresReplaceIfConfigured(),
+						stringplanmodifier.UseStateForUnknown(),
 					},
 					Validators: []validator.String{
 						stringvalidator.ExactlyOneOf(path.MatchRoot("edge_gateway_name"), path.MatchRoot("edge_gateway_id")),
@@ -80,6 +81,7 @@ func virtualServiceSchema(_ context.Context) superschema.Schema {
 					Computed:            true,
 					PlanModifiers: []planmodifier.String{
 						stringplanmodifier.RequiresReplaceIfConfigured(),
+						stringplanmodifier.UseStateForUnknown(),
 					},
 					Validators: []validator.String{
 						stringvalidator.ExactlyOneOf(path.MatchRoot("edge_gateway_name"), path.MatchRoot("edge_gateway_id")),

--- a/internal/provider/elb/virtual_service_types.go
+++ b/internal/provider/elb/virtual_service_types.go
@@ -91,7 +91,7 @@ func (rm *VirtualServiceModel) ToSDKVirtualServiceModelRequest(ctx context.Conte
 		}(),
 	}
 	if rm.ServiceEngineGroupName.IsKnown() {
-		seg, err := c.GetVirtualService(ctx, rm.EdgeGatewayID.Get(), rm.ServiceEngineGroupName.Get())
+		seg, err := c.GetServiceEngineGroup(ctx, rm.EdgeGatewayID.Get(), rm.ServiceEngineGroupName.Get())
 		if err != nil {
 			diags.AddError("Error getting service engine group", err.Error())
 			return nil, diags

--- a/internal/testsacc/acctest_datasources_test.go
+++ b/internal/testsacc/acctest_datasources_test.go
@@ -13,10 +13,6 @@ import "github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/he
 
 func GetDataSourceConfig() map[testsacc.ResourceName]func() *testsacc.ResourceConfig {
 	return map[testsacc.ResourceName]func() *testsacc.ResourceConfig{
-		// * ALB
-		ALBServiceEngineGroupDataSourceName:  testsacc.NewResourceConfig(NewALBServiceEngineGroupDataSourceTest()),
-		ALBServiceEngineGroupsDataSourceName: testsacc.NewResourceConfig(NewALBServiceEngineGroupsDataSourceTest()),
-
 		// * Catalog
 		CatalogDataSourceName:             testsacc.NewResourceConfig(NewCatalogDataSourceTest()),
 		CatalogACLDataSourceName:          testsacc.NewResourceConfig(NewCatalogACLDataSourceTest()),
@@ -58,6 +54,8 @@ func GetDataSourceConfig() map[testsacc.ResourceName]func() *testsacc.ResourceCo
 		EdgeGatewayStaticRouteDataSourceName:    testsacc.NewResourceConfig(NewEdgeGatewayStaticRouteDataSourceTest()),
 
 		// * EdgeGateway LoadBalancer (elb)
+		ELBServiceEngineGroupDataSourceName:   testsacc.NewResourceConfig(NewELBServiceEngineGroupDataSourceTest()),
+		ELBServiceEngineGroupsDataSourceName:  testsacc.NewResourceConfig(NewELBServiceEngineGroupsDataSourceTest()),
 		ELBPoolDataSourceName:                 testsacc.NewResourceConfig(NewELBPoolDataSourceTest()),
 		ELBVirtualServiceDataSourceName:       testsacc.NewResourceConfig(NewELBVirtualServiceDataSourceTest()),
 		ELBPoliciesHTTPRequestDataSourceName:  testsacc.NewResourceConfig(NewELBPoliciesHTTPRequestDataSourceTest()),

--- a/internal/testsacc/elb_service_engine_group_datasource_test.go
+++ b/internal/testsacc/elb_service_engine_group_datasource_test.go
@@ -19,30 +19,30 @@ import (
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/testsacc"
 )
 
-var _ testsacc.TestACC = &ALBServiceEngineGroupDataSource{}
+var _ testsacc.TestACC = &ELBServiceEngineGroupDataSource{}
 
 const (
-	ALBServiceEngineGroupDataSourceName = testsacc.ResourceName("data.cloudavenue_elb_service_engine_group")
+	ELBServiceEngineGroupDataSourceName = testsacc.ResourceName("data.cloudavenue_elb_service_engine_group")
 )
 
-type ALBServiceEngineGroupDataSource struct{}
+type ELBServiceEngineGroupDataSource struct{}
 
-func NewALBServiceEngineGroupDataSourceTest() testsacc.TestACC {
-	return &ALBServiceEngineGroupDataSource{}
+func NewELBServiceEngineGroupDataSourceTest() testsacc.TestACC {
+	return &ELBServiceEngineGroupDataSource{}
 }
 
 // GetResourceName returns the name of the resource.
-func (r *ALBServiceEngineGroupDataSource) GetResourceName() string {
-	return ALBServiceEngineGroupDataSourceName.String()
+func (r *ELBServiceEngineGroupDataSource) GetResourceName() string {
+	return ELBServiceEngineGroupDataSourceName.String()
 }
 
-func (r *ALBServiceEngineGroupDataSource) DependenciesConfig() (resp testsacc.DependenciesConfigResponse) {
-	resp.Append(GetDataSourceConfig()[EdgeGatewayDataSourceName]().GetSpecificConfig("example_with_id"))
-	resp.Append(GetDataSourceConfig()[ALBServiceEngineGroupsDataSourceName]().GetDefaultConfig)
+func (r *ELBServiceEngineGroupDataSource) DependenciesConfig() (resp testsacc.DependenciesConfigResponse) {
+	resp.Append(GetDataSourceConfig()[EdgeGatewayDataSourceName]().GetSpecificConfig("example_for_elb"))
+	resp.Append(GetDataSourceConfig()[ELBServiceEngineGroupsDataSourceName]().GetDefaultConfig)
 	return
 }
 
-func (r *ALBServiceEngineGroupDataSource) Tests(_ context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
+func (r *ELBServiceEngineGroupDataSource) Tests(_ context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
 	return map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test{
 		// * Test One (example)
 		"example": func(_ context.Context, resourceName string) testsacc.Test {
@@ -52,7 +52,7 @@ func (r *ALBServiceEngineGroupDataSource) Tests(_ context.Context) map[testsacc.
 					TFConfig: `
 					data "cloudavenue_elb_service_engine_group" "example" {
 						name = data.cloudavenue_elb_service_engine_groups.example.service_engine_groups.0.name
-						edge_gateway_name = data.cloudavenue_edgegateway.example_with_id.name
+						edge_gateway_name = data.cloudavenue_edgegateway.example_for_elb.name
 					}`,
 					Checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttrWith(resourceName, "id", urn.TestIsType(urn.ServiceEngineGroup)),
@@ -71,9 +71,9 @@ func (r *ALBServiceEngineGroupDataSource) Tests(_ context.Context) map[testsacc.
 				// ! Create testing
 				Create: testsacc.TFConfig{
 					TFConfig: `
-					data "cloudavenue_elb_service_engine_group" "example_with_id" {
+					data "cloudavenue_elb_service_engine_group" "example_for_elb" {
 						id = data.cloudavenue_elb_service_engine_groups.example.service_engine_groups.0.id
-						edge_gateway_name = data.cloudavenue_edgegateway.example_with_id.name
+						edge_gateway_name = data.cloudavenue_edgegateway.example_for_elb.name
 					}`,
 					// Here use resource config test to test the data source
 					// the field example is the name of the test
@@ -96,7 +96,7 @@ func (r *ALBServiceEngineGroupDataSource) Tests(_ context.Context) map[testsacc.
 					TFConfig: `
 					data "cloudavenue_elb_service_engine_group" "example_with_edge_id" {
 						id = data.cloudavenue_elb_service_engine_groups.example.service_engine_groups.0.id
-						edge_gateway_id = data.cloudavenue_edgegateway.example_with_id.id
+						edge_gateway_id = data.cloudavenue_edgegateway.example_for_elb.id
 					}`,
 					// Here use resource config test to test the data source
 					// the field example is the name of the test
@@ -119,7 +119,7 @@ func (r *ALBServiceEngineGroupDataSource) Tests(_ context.Context) map[testsacc.
 					TFConfig: `
 					data "cloudavenue_elb_service_engine_group" "example_with_name_and_edge_id" {
 						name = data.cloudavenue_elb_service_engine_groups.example.service_engine_groups.0.name
-						edge_gateway_id = data.cloudavenue_edgegateway.example_with_id.id
+						edge_gateway_id = data.cloudavenue_edgegateway.example_for_elb.id
 					}`,
 					// Here use resource config test to test the data source
 					// the field example is the name of the test
@@ -138,10 +138,10 @@ func (r *ALBServiceEngineGroupDataSource) Tests(_ context.Context) map[testsacc.
 	}
 }
 
-func TestAccALBServiceEngineGroupDataSource(t *testing.T) {
+func TestAccELBServiceEngineGroupDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		Steps:                    testsacc.GenerateTests(&ALBServiceEngineGroupDataSource{}),
+		Steps:                    testsacc.GenerateTests(&ELBServiceEngineGroupDataSource{}),
 	})
 }

--- a/internal/testsacc/elb_service_engine_groups_datasource_test.go
+++ b/internal/testsacc/elb_service_engine_groups_datasource_test.go
@@ -19,29 +19,29 @@ import (
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/testsacc"
 )
 
-var _ testsacc.TestACC = &ALBServiceEngineGroupsDataSource{}
+var _ testsacc.TestACC = &ELBServiceEngineGroupsDataSource{}
 
 const (
-	ALBServiceEngineGroupsDataSourceName = testsacc.ResourceName("data.cloudavenue_elb_service_engine_groups")
+	ELBServiceEngineGroupsDataSourceName = testsacc.ResourceName("data.cloudavenue_elb_service_engine_groups")
 )
 
-type ALBServiceEngineGroupsDataSource struct{}
+type ELBServiceEngineGroupsDataSource struct{}
 
-func NewALBServiceEngineGroupsDataSourceTest() testsacc.TestACC {
-	return &ALBServiceEngineGroupsDataSource{}
+func NewELBServiceEngineGroupsDataSourceTest() testsacc.TestACC {
+	return &ELBServiceEngineGroupsDataSource{}
 }
 
 // GetResourceName returns the name of the resource.
-func (r *ALBServiceEngineGroupsDataSource) GetResourceName() string {
-	return ALBServiceEngineGroupsDataSourceName.String()
+func (r *ELBServiceEngineGroupsDataSource) GetResourceName() string {
+	return ELBServiceEngineGroupsDataSourceName.String()
 }
 
-func (r *ALBServiceEngineGroupsDataSource) DependenciesConfig() (resp testsacc.DependenciesConfigResponse) {
-	resp.Append(GetDataSourceConfig()[EdgeGatewayDataSourceName]().GetSpecificConfig("example_with_id"))
+func (r *ELBServiceEngineGroupsDataSource) DependenciesConfig() (resp testsacc.DependenciesConfigResponse) {
+	resp.Append(GetDataSourceConfig()[EdgeGatewayDataSourceName]().GetSpecificConfig("example_for_elb"))
 	return
 }
 
-func (r *ALBServiceEngineGroupsDataSource) Tests(_ context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
+func (r *ELBServiceEngineGroupsDataSource) Tests(_ context.Context) map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test {
 	return map[testsacc.TestName]func(ctx context.Context, resourceName string) testsacc.Test{
 		// * Test One (example)
 		"example": func(_ context.Context, resourceName string) testsacc.Test {
@@ -50,7 +50,7 @@ func (r *ALBServiceEngineGroupsDataSource) Tests(_ context.Context) map[testsacc
 				Create: testsacc.TFConfig{
 					TFConfig: `
 					data "cloudavenue_elb_service_engine_groups" "example" {
-						edge_gateway_name = data.cloudavenue_edgegateway.example_with_id.name
+						edge_gateway_name = data.cloudavenue_edgegateway.example_for_elb.name
 					}`,
 					Checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -74,7 +74,7 @@ func (r *ALBServiceEngineGroupsDataSource) Tests(_ context.Context) map[testsacc
 				Create: testsacc.TFConfig{
 					TFConfig: `
 					data "cloudavenue_elb_service_engine_groups" "example_with_id" {
-						edge_gateway_id = data.cloudavenue_edgegateway.example_with_id.id
+						edge_gateway_id = data.cloudavenue_edgegateway.example_for_elb.id
 					}`,
 					Checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -95,10 +95,10 @@ func (r *ALBServiceEngineGroupsDataSource) Tests(_ context.Context) map[testsacc
 	}
 }
 
-func TestAccALBServiceEngineGroupsDataSource(t *testing.T) {
+func TestAccELBServiceEngineGroupsDataSource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: TestAccProtoV6ProviderFactories,
-		Steps:                    testsacc.GenerateTests(&ALBServiceEngineGroupsDataSource{}),
+		Steps:                    testsacc.GenerateTests(&ELBServiceEngineGroupsDataSource{}),
 	})
 }


### PR DESCRIPTION

This pull request addresses a bug fix, schema updates, and test adjustments for the `cloudavenue_elb_virtual_service` resource and related components. The most notable changes include fixing a bug in retrieving the `service_engine_group_name`, updating schema plan modifiers, and renaming and refactoring test files for consistency.

### Bug Fixes:
* Fixed an issue where the `service_engine_group_name` attribute was not retrieved correctly if set. (`.changelog/1142.txt`, [.changelog/1142.txtR1-R3](diffhunk://#diff-4ac8f637e71c85f51eb4276c78f564909b82a83325637ef32a4c365d9471ea15R1-R3))
* Updated the method call in `virtual_service_types.go` to correctly use `GetServiceEngineGroup` instead of `GetVirtualService`. (`internal/provider/elb/virtual_service_types.go`, [internal/provider/elb/virtual_service_types.goL94-R94](diffhunk://#diff-335f253759241755e4074b1184ce8099da29a2d7c2af2738b6b19f821b24f8edL94-R94))

### Schema Updates:
* Added the `UseStateForUnknown` plan modifier to schema definitions in `virtual_service_schema.go` to improve handling of unknown states. (`internal/provider/elb/virtual_service_schema.go`, [[1]](diffhunk://#diff-17a44949fc363176efbddc3047ab724986178423b64416557467cea5547a407eR70) [[2]](diffhunk://#diff-17a44949fc363176efbddc3047ab724986178423b64416557467cea5547a407eR84)

### Test Refactoring:
* Renamed and updated test files to replace "ALB" with "ELB" for consistency and clarity:
  - `edgegateway_lb_service_engine_group_datasource_test.go` → `elb_service_engine_group_datasource_test.go` with corresponding updates to variable names and test configurations. (`internal/testsacc/elb_service_engine_group_datasource_test.go`, [[1]](diffhunk://#diff-22d52160f674d31f5a86d6456d400225c1304bdc2e147830b533909a00f9ca0dL22-R45) [[2]](diffhunk://#diff-22d52160f674d31f5a86d6456d400225c1304bdc2e147830b533909a00f9ca0dL55-R55) [[3]](diffhunk://#diff-22d52160f674d31f5a86d6456d400225c1304bdc2e147830b533909a00f9ca0dL141-R145)
  - `edgegateway_lb_service_engine_groups_datasource_test.go` → `elb_service_engine_groups_datasource_test.go` with similar updates. (`internal/testsacc/elb_service_engine_groups_datasource_test.go`, [[1]](diffhunk://#diff-2fdd92d22b9534304f04f7b31e237b964efbdcbcef9fc2e27002565484c4e069L22-R44) [[2]](diffhunk://#diff-2fdd92d22b9534304f04f7b31e237b964efbdcbcef9fc2e27002565484c4e069L98-R102)

### Test Enhancements:
* Added a new test case for `cloudavenue_elb_virtual_service` to validate configurations with the `service_engine_group_name` attribute. (`internal/testsacc/elb_virtual_service_resource_test.go`, [internal/testsacc/elb_virtual_service_resource_test.goR606-R652](diffhunk://#diff-3c96dd2adcb3f47964810ced50fc747088a08828cee4ea0b99b7736c2773b2d3R606-R652))

### How has this code been tested

```
==============================================================================
--- PASS: TestAccELBVirtualServiceResource (529.36s)
PASS
ok  	github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc	529.852s
```