### PR TITLE
fix: failed to create SAML user

### DIFF
--- a/.changelog/1167.txt
+++ b/.changelog/1167.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_iam_user_saml` - Fixed issue when creating a SAML user return an error.
+```

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/madflojo/testcerts v1.4.0
-	github.com/orange-cloudavenue/cloudavenue-sdk-go v0.26.2
+	github.com/orange-cloudavenue/cloudavenue-sdk-go v0.26.3
 	github.com/orange-cloudavenue/common-go/print v0.0.0-20250109171729-2be550d5d3ac
 	github.com/orange-cloudavenue/common-go/utils v0.0.0-20240119163616-66b473d92339
 	github.com/orange-cloudavenue/common-go/validators v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/orange-cloudavenue/cloudavenue-sdk-go v0.26.2 h1:5/Roai/AjliSAnwSa9LKfzanBnnFZJlQazyIOjD783I=
-github.com/orange-cloudavenue/cloudavenue-sdk-go v0.26.2/go.mod h1:eAXf0Rw0vYeQyPdcd+Bo+A1fekQGwgM7WRl8GdskfyU=
+github.com/orange-cloudavenue/cloudavenue-sdk-go v0.26.3 h1:vqIxQM3driBlCpxHzkEK02vLw8Ux3/TWD9p3CDGcyaY=
+github.com/orange-cloudavenue/cloudavenue-sdk-go v0.26.3/go.mod h1:eAXf0Rw0vYeQyPdcd+Bo+A1fekQGwgM7WRl8GdskfyU=
 github.com/orange-cloudavenue/common-go/print v0.0.0-20250109171729-2be550d5d3ac h1:f1Fd70+PMDTK6FE4gHdNfoHSQHLn5pfJMTjZPzOWZtc=
 github.com/orange-cloudavenue/common-go/print v0.0.0-20250109171729-2be550d5d3ac/go.mod h1:IYtCusqpEGS0dhC6F8X9GHrrt1gp1zHaNhSKGYV59Xg=
 github.com/orange-cloudavenue/common-go/utils v0.0.0-20240119163616-66b473d92339 h1:DEKcWLGbEhu/I6kn9NAXhVCFrbPhR+Ef7oLmpLVnnPM=

--- a/internal/provider/iam/user_saml_resource.go
+++ b/internal/provider/iam/user_saml_resource.go
@@ -113,7 +113,7 @@ func (r *UserSAMLResource) Create(ctx context.Context, req resource.CreateReques
 			resp.Diagnostics.AddError("User not found after create", fmt.Sprintf("User with name %s not found after create", plan.UserName.Get()))
 			return
 		}
-		resp.Diagnostics.AddError("Error creating user", err.Error())
+		resp.Diagnostics.AddError("Error creating user SAML", err.Error())
 		return
 	}
 


### PR DESCRIPTION
This pull request addresses a bug related to the creation of SAML users in the `resource/cloudavenue_iam_user_saml` resource. It also updates a dependency to the latest version and improves error messaging for better clarity.

Bug fix:

* Fixed an issue where creating a SAML user could return an error in the `resource/cloudavenue_iam_user_saml` resource. (`.changelog/1167.txt`, [.changelog/1167.txtR1-R2](diffhunk://#diff-3ef292c3c1923ea926884fa4ecc41284d75b52c8614d7cfc584a1c9ee8d45a9aR1-R2))

Dependency update:

* Updated the `github.com/orange-cloudavenue/cloudavenue-sdk-go` dependency from version `v0.26.2` to `v0.26.3` in `go.mod`.

Error handling improvement:

* Improved the error message when user creation fails, specifying "Error creating user SAML" instead of the generic "Error creating user" in `internal/provider/iam/user_saml_resource.go`.