### PR TITLE
chore: align organization with SDKV2

### DIFF
--- a/docs/data-sources/org.md
+++ b/docs/data-sources/org.md
@@ -28,17 +28,4 @@ data "cloudavenue_org" "example" {
 - `id` (String) The ID of the organization.
 - `internet_billing_mode` (String) The organization's Internet bandwidth billing method.
 - `name` (String) The name of the organization.
-- `resources` (Attributes) The resource usage of the organization. (see [below for nested schema](#nestedatt--resources))
-
-<a id="nestedatt--resources"></a>
-### Nested Schema for `resources`
-
-Read-Only:
-
-- `catalog` (Number) The number of catalogs in the organization.
-- `disk` (Number) The number of standalone disks in the organization.
-- `user` (Number) The number of users in the organization.
-- `vapp` (Number) The number of vApps in the organization.
-- `vdc` (Number) The number of VDCs in the organization.
-- `vm_running` (Number) The number of running VMs in the organization.
 

--- a/docs/resources/org.md
+++ b/docs/resources/org.md
@@ -50,19 +50,6 @@ resource "cloudavenue_org" "example" {
 - `enabled` (Boolean) Indicates whether the organization is enabled.
 - `id` (String) The ID of the organization.
 - `name` (String) The name of the organization.
-- `resources` (Attributes) The resource usage of the organization. (see [below for nested schema](#nestedatt--resources))
-
-<a id="nestedatt--resources"></a>
-### Nested Schema for `resources`
-
-Read-Only:
-
-- `catalog` (Number) The number of catalogs in the organization.
-- `disk` (Number) The number of standalone disks in the organization.
-- `user` (Number) The number of users in the organization.
-- `vapp` (Number) The number of vApps in the organization.
-- `vdc` (Number) The number of VDCs in the organization.
-- `vm_running` (Number) The number of running VMs in the organization.
 
 ## Import
 

--- a/internal/provider/org/org_schema.go
+++ b/internal/provider/org/org_schema.go
@@ -88,50 +88,6 @@ func orgSchema(_ context.Context) superschema.Schema {
 					Computed:            true,
 				},
 			},
-			"resources": superschema.SuperSingleNestedAttributeOf[OrgModelResources]{
-				Common: &schemaR.SingleNestedAttribute{
-					MarkdownDescription: "The resource usage of the organization.",
-					Computed:            true,
-				},
-				Attributes: superschema.Attributes{
-					"vdc": superschema.SuperInt64Attribute{
-						Common: &schemaR.Int64Attribute{
-							MarkdownDescription: "The number of VDCs in the organization.",
-							Computed:            true,
-						},
-					},
-					"catalog": superschema.SuperInt64Attribute{
-						Common: &schemaR.Int64Attribute{
-							MarkdownDescription: "The number of catalogs in the organization.",
-							Computed:            true,
-						},
-					},
-					"vapp": superschema.SuperInt64Attribute{
-						Common: &schemaR.Int64Attribute{
-							MarkdownDescription: "The number of vApps in the organization.",
-							Computed:            true,
-						},
-					},
-					"vm_running": superschema.SuperInt64Attribute{
-						Common: &schemaR.Int64Attribute{
-							MarkdownDescription: "The number of running VMs in the organization.",
-							Computed:            true,
-						},
-					},
-					"user": superschema.SuperInt64Attribute{
-						Common: &schemaR.Int64Attribute{
-							MarkdownDescription: "The number of users in the organization.",
-							Computed:            true,
-						},
-					},
-					"disk": superschema.SuperInt64Attribute{
-						Common: &schemaR.Int64Attribute{
-							MarkdownDescription: "The number of standalone disks in the organization.",
-							Computed:            true,
-						},
-					},
-				},
-			},
 		},
 	}
 }

--- a/internal/provider/org/org_types.go
+++ b/internal/provider/org/org_types.go
@@ -22,23 +22,13 @@ import (
 
 type (
 	OrgModel struct { //nolint:revive
-		ID                  supertypes.StringValue                                  `tfsdk:"id"`
-		Name                supertypes.StringValue                                  `tfsdk:"name"`
-		Description         supertypes.StringValue                                  `tfsdk:"description"`
-		FullName            supertypes.StringValue                                  `tfsdk:"full_name"`
-		Enabled             supertypes.BoolValue                                    `tfsdk:"enabled"`
-		Email               supertypes.StringValue                                  `tfsdk:"email"`
-		InternetBillingMode supertypes.StringValue                                  `tfsdk:"internet_billing_mode"`
-		Resources           supertypes.SingleNestedObjectValueOf[OrgModelResources] `tfsdk:"resources"`
-	}
-
-	OrgModelResources struct { //nolint:revive
-		VDC       supertypes.Int64Value `tfsdk:"vdc"`
-		Catalog   supertypes.Int64Value `tfsdk:"catalog"`
-		Vapp      supertypes.Int64Value `tfsdk:"vapp"`
-		VMRunning supertypes.Int64Value `tfsdk:"vm_running"`
-		User      supertypes.Int64Value `tfsdk:"user"`
-		Disk      supertypes.Int64Value `tfsdk:"disk"`
+		ID                  supertypes.StringValue `tfsdk:"id"`
+		Name                supertypes.StringValue `tfsdk:"name"`
+		Description         supertypes.StringValue `tfsdk:"description"`
+		FullName            supertypes.StringValue `tfsdk:"full_name"`
+		Enabled             supertypes.BoolValue   `tfsdk:"enabled"`
+		Email               supertypes.StringValue `tfsdk:"email"`
+		InternetBillingMode supertypes.StringValue `tfsdk:"internet_billing_mode"`
 	}
 )
 
@@ -49,6 +39,8 @@ func (rm *OrgModel) Copy() *OrgModel {
 }
 
 func (data *OrgModel) fromModel(ctx context.Context, o *types.ModelGetOrganization) (diags diag.Diagnostics) {
+	// ctx kept for future use; avoid unused param linter error after resources.* removal
+	_ = ctx
 	if o == nil {
 		diags.AddError("Error reading organization", "Received nil organization from API")
 		return diags
@@ -60,14 +52,6 @@ func (data *OrgModel) fromModel(ctx context.Context, o *types.ModelGetOrganizati
 	data.Enabled.Set(o.Enabled)
 	data.Email.Set(o.Email)
 	data.InternetBillingMode.Set(o.InternetBillingMode)
-	resources := &OrgModelResources{}
-	resources.VDC.SetInt(o.Resources.Vdc)
-	resources.Catalog.SetInt(o.Resources.Catalog)
-	resources.Vapp.SetInt(o.Resources.Vapp)
-	resources.VMRunning.SetInt(o.Resources.VMRunning)
-	resources.User.SetInt(o.Resources.User)
-	resources.Disk.SetInt(o.Resources.Disk)
-	diags.Append(data.Resources.Set(ctx, resources)...)
 
 	return diags
 }

--- a/internal/testsacc/org_resource_test.go
+++ b/internal/testsacc/org_resource_test.go
@@ -52,13 +52,6 @@ func (r *OrgResource) Tests(_ context.Context) map[testsacc.TestName]func(ctx co
 					resource.TestCheckResourceAttrWith(resourceName, "id", helpers.TestIsType(urn.Org)),
 					resource.TestMatchResourceAttr(resourceName, "name", regex.OrganizationNameRegex()),
 					resource.TestCheckResourceAttrSet(resourceName, "enabled"),
-					resource.TestCheckResourceAttrSet(resourceName, "resources.%"),
-					resource.TestCheckResourceAttrSet(resourceName, "resources.vdc"),
-					resource.TestCheckResourceAttrSet(resourceName, "resources.catalog"),
-					resource.TestCheckResourceAttrSet(resourceName, "resources.vapp"),
-					resource.TestCheckResourceAttrSet(resourceName, "resources.vm_running"),
-					resource.TestCheckResourceAttrSet(resourceName, "resources.user"),
-					resource.TestCheckResourceAttrSet(resourceName, "resources.disk"),
 				},
 				// ! Import testing with data source
 				// Import is tested with data source because create is not possible


### PR DESCRIPTION
This pull request removes the `resources` attribute and its nested fields (such as `vdc`, `catalog`, `vapp`, `vm_running`, `user`, and `disk`) from the organization schema, documentation, and acceptance tests. This simplifies the organization model by eliminating resource usage details, which are no longer tracked or exposed.

Schema and type changes:
- Removed the `resources` nested attribute and its subfields from the organization schema in `org_schema.go` and the corresponding type definitions in `org_types.go`. [[1]](diffhunk://#diff-2dda431a6b5e12093fa259d6e65230c9295e86cc49c27454420fcf447cbb6ae9L91-L134) [[2]](diffhunk://#diff-2e893dd53d9e657f58e6728b05cec9402e3bfbf34be33f5403a9b8999444dca2L32-L41)
- Updated the `fromModel` method in `org_types.go` to eliminate population of the `resources` field and its subfields.
- Added a comment in `fromModel` to clarify the unused `ctx` parameter after removing `resources` handling.

Documentation updates:
- Removed documentation for the `resources` attribute and its nested schema from both the data source (`org.md`) and resource (`org.md`) documentation files. [[1]](diffhunk://#diff-3d847587cd9a9a4427aaa8a5119981231ef162f1038f09e08131436fe592ed90L31-L43) [[2]](diffhunk://#diff-70e841e836940adb68ae454dfc6ee3b36f3ac9582aaddbeae9ccd15a9450cb5cL53-L65)

Testing adjustments:
- Removed all acceptance test checks related to the `resources` attribute and its subfields in `org_resource_test.go`.

-->

If you submit change in the provider code, please make sure to:

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

```
--- PASS: TestAccOrgResource (78.56s)
PASS
ok      github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/testsacc  79.080s
```