### PR TITLE
fix: missing return in some init functions

### DIFF
--- a/.changelog/1199.txt
+++ b/.changelog/1199.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed a missing return in some initialization functions that could cause a panic if there was an API error.
+```

--- a/internal/provider/elb/pool_resource.go
+++ b/internal/provider/elb/pool_resource.go
@@ -56,6 +56,7 @@ func (r *PoolResource) Init(_ context.Context, rm *PoolModel) (diags diag.Diagno
 	r.elb, err = edgeloadbalancer.NewClient()
 	if err != nil {
 		diags.AddError("Error creating elb client", err.Error())
+		return diags
 	}
 
 	eIDOrName := rm.EdgeGatewayID.Get()
@@ -65,6 +66,7 @@ func (r *PoolResource) Init(_ context.Context, rm *PoolModel) (diags diag.Diagno
 	r.edge, err = r.client.CAVSDK.V1.EdgeGateway.Get(eIDOrName)
 	if err != nil {
 		diags.AddError("Error creating edge client", err.Error())
+		return diags
 	}
 
 	rm.EdgeGatewayID.Set(urn.Normalize(urn.Gateway, r.edge.GetID()).String())

--- a/internal/provider/elb/virtual_service_datasource.go
+++ b/internal/provider/elb/virtual_service_datasource.go
@@ -47,6 +47,7 @@ func (d *VirtualServiceDataSource) Init(_ context.Context, dm *VirtualServiceMod
 	d.elb, err = edgeloadbalancer.NewClient()
 	if err != nil {
 		diags.AddError("Error creating elb client", err.Error())
+		return diags
 	}
 
 	eIDOrName := dm.EdgeGatewayID.Get()
@@ -56,6 +57,7 @@ func (d *VirtualServiceDataSource) Init(_ context.Context, dm *VirtualServiceMod
 	d.edge, err = d.client.CAVSDK.V1.EdgeGateway.Get(eIDOrName)
 	if err != nil {
 		diags.AddError("Error creating edge client", err.Error())
+		return diags
 	}
 
 	dm.EdgeGatewayID.Set(urn.Normalize(urn.Gateway, d.edge.GetID()).String())

--- a/internal/provider/elb/virtual_service_resource.go
+++ b/internal/provider/elb/virtual_service_resource.go
@@ -59,6 +59,7 @@ func (r *VirtualServiceResource) Init(_ context.Context, rm *VirtualServiceModel
 	r.elb, err = edgeloadbalancer.NewClient()
 	if err != nil {
 		diags.AddError("Error creating elb client", err.Error())
+		return diags
 	}
 
 	eIDOrName := rm.EdgeGatewayID.Get()
@@ -68,6 +69,7 @@ func (r *VirtualServiceResource) Init(_ context.Context, rm *VirtualServiceModel
 	r.edge, err = r.client.CAVSDK.V1.EdgeGateway.Get(eIDOrName)
 	if err != nil {
 		diags.AddError("Error creating edge client", err.Error())
+		return diags
 	}
 
 	rm.EdgeGatewayID.Set(urn.Normalize(urn.Gateway, r.edge.GetID()).String())

--- a/internal/provider/org/certificate_library_resource.go
+++ b/internal/provider/org/certificate_library_resource.go
@@ -50,6 +50,7 @@ func (r *CertificateLibraryResource) Init(_ context.Context, _ *CertificateLibra
 	org, err := r.client.CAVSDK.V1.Org()
 	if err != nil {
 		diags.AddError("Error initializing ORG client", err.Error())
+		return diags
 	}
 
 	r.orgClient = org.Client


### PR DESCRIPTION
This pull request improves error handling in the resource initialization logic across several provider modules. Now, if a client initialization fails, the function will return early, preventing subsequent code from running with invalid state. This change makes the code more robust and prevents potential runtime errors when dependencies are not properly initialized.

Error handling improvements:

* Added early returns after error detection in `Init` methods for `PoolResource`, `VirtualServiceResource`, and `VirtualServiceDataSource` to ensure the function exits immediately if the ELB client or Edge client initialization fails (`internal/provider/elb/pool_resource.go`, `internal/provider/elb/virtual_service_resource.go`, `internal/provider/elb/virtual_service_datasource.go`). [[1]](diffhunk://#diff-d1f33afec9e0377c4a27271f132bb0b6c3b587c95be73ac03592c8c82694cb0eR59) [[2]](diffhunk://#diff-d1f33afec9e0377c4a27271f132bb0b6c3b587c95be73ac03592c8c82694cb0eR69) [[3]](diffhunk://#diff-31471275470b2b13f969d893f6f7eef2bea402503e5199e0ef773128020bd259R62) [[4]](diffhunk://#diff-31471275470b2b13f969d893f6f7eef2bea402503e5199e0ef773128020bd259R72) [[5]](diffhunk://#diff-3fc202fea9850136f36796619c59b254f352a7dd56498c279dea11399f967aa5R50) [[6]](diffhunk://#diff-3fc202fea9850136f36796619c59b254f352a7dd56498c279dea11399f967aa5R60)
* Added an early return in the `Init` method of `CertificateLibraryResource` if the Org client initialization fails (`internal/provider/org/certificate_library_resource.go`).<!--
Thank you for helping to improve Terraform Cloud Avenue provider!
-->
