### PR TITLE
fix: s3 client

### DIFF
--- a/.changelog/1201.txt
+++ b/.changelog/1201.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fix panic in the authentication s3 method. 
+```

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/madflojo/testcerts v1.4.0
-	github.com/orange-cloudavenue/cloudavenue-sdk-go v0.27.0
+	github.com/orange-cloudavenue/cloudavenue-sdk-go v0.27.1
 	github.com/orange-cloudavenue/common-go/print v0.0.0-20250109171729-2be550d5d3ac
 	github.com/orange-cloudavenue/common-go/utils v0.0.0-20240119163616-66b473d92339
 	github.com/orange-cloudavenue/common-go/validators v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/orange-cloudavenue/cloudavenue-sdk-go v0.27.0 h1:4MC1aW97tBWD9R03AskLh8fxGGlENjv+EzW1kJnWTCY=
-github.com/orange-cloudavenue/cloudavenue-sdk-go v0.27.0/go.mod h1:eAXf0Rw0vYeQyPdcd+Bo+A1fekQGwgM7WRl8GdskfyU=
+github.com/orange-cloudavenue/cloudavenue-sdk-go v0.27.1 h1:aGHarDsF6J1FWuAEjhqIQqhaVHv7D7y9yGXAOrJWEGY=
+github.com/orange-cloudavenue/cloudavenue-sdk-go v0.27.1/go.mod h1:eAXf0Rw0vYeQyPdcd+Bo+A1fekQGwgM7WRl8GdskfyU=
 github.com/orange-cloudavenue/common-go/print v0.0.0-20250109171729-2be550d5d3ac h1:f1Fd70+PMDTK6FE4gHdNfoHSQHLn5pfJMTjZPzOWZtc=
 github.com/orange-cloudavenue/common-go/print v0.0.0-20250109171729-2be550d5d3ac/go.mod h1:IYtCusqpEGS0dhC6F8X9GHrrt1gp1zHaNhSKGYV59Xg=
 github.com/orange-cloudavenue/common-go/utils v0.0.0-20240119163616-66b473d92339 h1:DEKcWLGbEhu/I6kn9NAXhVCFrbPhR+Ef7oLmpLVnnPM=


### PR DESCRIPTION
This pull request updates a dependency version in the `go.mod` file. The change ensures the project uses a newer release of the `cloudavenue-sdk-go` library, which may include important bug fixes or enhancements.

Dependency update:

* Upgraded `github.com/orange-cloudavenue/cloudavenue-sdk-go` from version `v0.27.0` to `v0.27.1` in `go.mod`.