### PR TITLE
fix(vapp_org_network): refresh vApp after lock to prevent stale paral…

### DIFF
--- a/.changelog/1204.txt
+++ b/.changelog/1204.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+`resource/cloudavenue_vapp_org_network` - Fix parallel attachment of multiple org networks to the same vApp. The vApp state is now refreshed after acquiring the lock in Create, Read and Delete operations, preventing stale data from silently overwriting previous network attachments (issue #1202).
+```

--- a/internal/provider/common/vapp/vapp.go
+++ b/internal/provider/common/vapp/vapp.go
@@ -42,6 +42,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 
 	v1 "github.com/orange-cloudavenue/cloudavenue-sdk-go/v1"
+
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/client"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/mutex"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/vdc"
@@ -200,5 +201,6 @@ func (v VAPP) UnlockVAPP(ctx context.Context) (d diag.Diagnostics) {
 	}
 	key := fmt.Sprintf("vdc:%s|vapp:%s", v.vdc.GetName(), v.GetName())
 	vcdMutexKV.KvUnlock(ctx, key)
+
 	return d
 }

--- a/internal/provider/vapp/org_network_resource.go
+++ b/internal/provider/vapp/org_network_resource.go
@@ -35,6 +35,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
+
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/client"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/metrics"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/network"
@@ -130,6 +131,10 @@ func (r *orgNetworkResource) Create(ctx context.Context, req resource.CreateRequ
 	}
 	defer r.vapp.UnlockVAPP(ctx)
 
+	if err := r.vapp.Refresh(); err != nil {
+		resp.Diagnostics.AddError("Error refreshing vApp", err.Error())
+	}
+
 	orgNetworkName := plan.NetworkName.ValueString()
 	orgNetwork, err := r.vdc.GetOrgVdcNetworkByNameOrId(orgNetworkName, true)
 	if err != nil {
@@ -202,6 +207,10 @@ func (r *orgNetworkResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	defer r.vapp.UnlockVAPP(ctx)
 
+	if err := r.vapp.Refresh(); err != nil {
+		resp.Diagnostics.AddError("Error refreshing vApp", err.Error())
+	}
+
 	vAppNetworkConfig, err := r.vapp.GetNetworkConfig()
 	if err != nil {
 		resp.Diagnostics.AddError("Error retrieving vApp network config", err.Error())
@@ -261,6 +270,10 @@ func (r *orgNetworkResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 	defer r.vapp.UnlockVAPP(ctx)
+
+	if err := r.vapp.Refresh(); err != nil {
+		resp.Diagnostics.AddError("Error refreshing vApp", err.Error())
+	}
 
 	// Vapp Statuses
 	// 1:  "RESOLVED",

--- a/internal/testsacc/vapp_org_network_resource_test.go
+++ b/internal/testsacc/vapp_org_network_resource_test.go
@@ -20,9 +20,11 @@ package testsacc
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/helpers/testsacc"
@@ -83,6 +85,123 @@ func (r *VAppOrgNetworkResource) Tests(_ context.Context) map[testsacc.TestName]
 						ImportStateVerify:    true,
 					},
 				},
+			}
+		},
+
+		// * Test named "example_multiple_networks"
+		// Reproduces issue #1202: when multiple org networks are attached to the same vApp
+		// in parallel (no explicit depends_on), only the first one actually attaches and
+		// the others silently fail, causing the next plan to error with
+		// "Unable to find network in the VApp".
+		"example_multiple_networks": func(_ context.Context, resourceName string) testsacc.Test {
+			// resourceName = "cloudavenue_vapp_org_network.example_multiple_networks" (first resource)
+			const secondResourceName = "cloudavenue_vapp_org_network.example_multiple_networks_second"
+			const secondNetworkResourceName = "cloudavenue_network_routed.example_multiple_networks_second"
+
+			return testsacc.Test{
+				CommonDependencies: func() (resp testsacc.DependenciesConfigResponse) {
+					resp.Append(func() map[string]testsacc.TFData {
+						return map[string]testsacc.TFData{
+							secondNetworkResourceName: testsacc.GenerateFromTemplate(secondNetworkResourceName, `
+							resource "cloudavenue_network_routed" "example_multiple_networks_second" {
+								name        = {{ generate . "name_second" }}
+								edge_gateway_id = cloudavenue_edgegateway.example.id
+
+								gateway       = "192.168.2.254"
+								prefix_length = 24
+
+								dns1 = "1.1.1.1"
+								dns2 = "8.8.8.8"
+
+								dns_suffix = "example"
+
+								static_ip_pool = [
+								  {
+									start_address = "192.168.2.10"
+									end_address   = "192.168.2.20"
+								  }
+								]
+							}`),
+						}
+					})
+					return resp
+				},
+				CommonChecks: []resource.TestCheckFunc{
+					// Checks for the first org network
+					resource.TestCheckResourceAttrWith(resourceName, "id", urn.TestIsType(urn.Network)),
+					resource.TestCheckResourceAttrSet(resourceName, "vdc"),
+					resource.TestCheckResourceAttrSet(resourceName, "network_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "vapp_name"),
+					// Checks for the second org network
+					resource.TestCheckResourceAttrWith(secondResourceName, "id", urn.TestIsType(urn.Network)),
+					resource.TestCheckResourceAttrSet(secondResourceName, "vdc"),
+					resource.TestCheckResourceAttrSet(secondResourceName, "network_name"),
+					resource.TestCheckResourceAttrSet(secondResourceName, "vapp_name"),
+				},
+				// ! Create testing — both resources are created in parallel (no depends_on)
+				// to reproduce the race condition described in issue #1202.
+				Create: testsacc.TFConfig{
+					TFConfig: testsacc.GenerateFromTemplate(resourceName, `
+					resource "cloudavenue_vapp_org_network" "example_multiple_networks" {
+						vapp_name    = cloudavenue_vapp.example.name
+						network_name = cloudavenue_network_routed.example.name
+						vdc          = cloudavenue_vdc.example.name
+					}
+
+					resource "cloudavenue_vapp_org_network" "example_multiple_networks_second" {
+						vapp_name    = cloudavenue_vapp.example.name
+						network_name = cloudavenue_network_routed.example_multiple_networks_second.name
+						vdc          = cloudavenue_vdc.example.name
+					}`),
+					// Verify that the two resources received distinct IDs — a silent overwrite
+					// would leave both pointing to the same network URN.
+					Checks: []resource.TestCheckFunc{
+						func(s *terraform.State) error {
+							first, ok := s.RootModule().Resources[resourceName]
+							if !ok {
+								return fmt.Errorf("resource %s not found in state", resourceName)
+							}
+							second, ok := s.RootModule().Resources[secondResourceName]
+							if !ok {
+								return fmt.Errorf("resource %s not found in state", secondResourceName)
+							}
+							idFirst := first.Primary.ID
+							idSecond := second.Primary.ID
+							if idFirst == idSecond {
+								return fmt.Errorf("expected distinct IDs for both org networks, got the same: %s", idFirst)
+							}
+							return nil
+						},
+					},
+				},
+				// ! Update testing
+				// Run a plan-only step to trigger Read/refresh on both resources.
+				// Before the bug fix, Read calls findOrgNetwork and errors with
+				// "Unable to find network in the VApp" for the silently dropped resource.
+				// After the fix, both reads succeed and the plan is empty.
+				Updates: []testsacc.TFConfig{
+					{
+						TFConfig: testsacc.GenerateFromTemplate(resourceName, `
+						resource "cloudavenue_vapp_org_network" "example_multiple_networks" {
+							vapp_name    = cloudavenue_vapp.example.name
+							network_name = cloudavenue_network_routed.example.name
+							vdc          = cloudavenue_vdc.example.name
+						}
+
+						resource "cloudavenue_vapp_org_network" "example_multiple_networks_second" {
+							vapp_name    = cloudavenue_vapp.example.name
+							network_name = cloudavenue_network_routed.example_multiple_networks_second.name
+							vdc          = cloudavenue_vdc.example.name
+						}`),
+						TFAdvanced: testsacc.TFAdvanced{
+							PlanOnly:           true,
+							ExpectNonEmptyPlan: false,
+						},
+						Checks: []resource.TestCheckFunc{},
+					},
+				},
+				// ! Imports testing
+				// * No imports for this test
 			}
 		},
 	}


### PR DESCRIPTION
This pull request addresses a critical bug in the `cloudavenue_vapp_org_network` resource that caused issues when attaching multiple org networks to the same vApp in parallel. The changes ensure the vApp state is properly refreshed after acquiring the lock during Create, Read, and Delete operations, preventing stale data from overwriting previous network attachments. Additionally, a new acceptance test is added to reproduce and verify the fix for this race condition.

**Bug Fixes and State Management:**

* Ensured that the vApp state is refreshed after acquiring the lock in the `Create`, `Read`, and `Delete` operations of `orgNetworkResource`, preventing stale data from causing silent overwrites when attaching multiple org networks in parallel. This directly addresses issue #1202. [[1]](diffhunk://#diff-61b4ab8d2fc2f57cf67ec581bed4a87dd613e9e4497f89cdcf71c1b7f86bb4d5R134-R137) [[2]](diffhunk://#diff-61b4ab8d2fc2f57cf67ec581bed4a87dd613e9e4497f89cdcf71c1b7f86bb4d5R210-R213) [[3]](diffhunk://#diff-61b4ab8d2fc2f57cf67ec581bed4a87dd613e9e4497f89cdcf71c1b7f86bb4d5R274-R277)

**Testing Improvements:**

* Added a new acceptance test (`example_multiple_networks`) in `vapp_org_network_resource_test.go` to reproduce the parallel attachment issue and verify that both org networks are correctly attached and have distinct IDs, ensuring the bug is fixed.
* Enhanced test imports and checks to support the new scenario and validate the fix.

**Documentation:**

* Added a release note describing the bug fix for parallel attachment of org networks to a vApp, referencing issue #1202. (.changelog/1204.txt)

**Code Maintenance:**

* Minor import cleanup and formatting in affected files for consistency. [[1]](diffhunk://#diff-ac47d2e371e4d4fedaab89231dabe15d52c49c239cef5a380c858bd99f53b179R45) [[2]](diffhunk://#diff-61b4ab8d2fc2f57cf67ec581bed4a87dd613e9e4497f89cdcf71c1b7f86bb4d5R38) [[3]](diffhunk://#diff-ac47d2e371e4d4fedaab89231dabe15d52c49c239cef5a380c858bd99f53b179R204)

These changes collectively improve the stability and correctness of network attachment operations in environments where resources are managed in parallel.