### PR TITLE
fix: update template_name to UBUNTU_22.04 in acceptance tests

### DIFF
--- a/internal/testsacc/catalog_vapp_template_datasource_test.go
+++ b/internal/testsacc/catalog_vapp_template_datasource_test.go
@@ -60,7 +60,7 @@ func (r *CatalogVAppTemplateDataSource) Tests(_ context.Context) map[testsacc.Te
 					TFConfig: `
 					data "cloudavenue_catalog_vapp_template" "example" {
 						catalog_name  	= "Orange-Linux"
-						template_name 	= "UBUNTU_20.04"
+						template_name 	= "UBUNTU_22.04"
 					}`,
 					Checks: []resource.TestCheckFunc{
 						resource.TestCheckResourceAttrWith(resourceName, "id", urn.TestIsType(urn.VAPPTemplate)),
@@ -68,7 +68,7 @@ func (r *CatalogVAppTemplateDataSource) Tests(_ context.Context) map[testsacc.Te
 						resource.TestCheckResourceAttr(resourceName, "catalog_name", "Orange-Linux"),
 						resource.TestCheckResourceAttrWith(resourceName, "catalog_id", urn.TestIsType(urn.Catalog)),
 
-						resource.TestCheckResourceAttr(resourceName, "template_name", "UBUNTU_20.04"),
+						resource.TestCheckResourceAttr(resourceName, "template_name", "UBUNTU_22.04"),
 						resource.TestCheckResourceAttrWith(resourceName, "template_id", urn.TestIsType(urn.VAPPTemplate)),
 						// Other
 						resource.TestCheckResourceAttrSet(resourceName, "created_at"),

--- a/internal/testsacc/vm_datasource_test.go
+++ b/internal/testsacc/vm_datasource_test.go
@@ -30,7 +30,7 @@ import (
 const testAccVMDataSourceConfig = `
 data "cloudavenue_catalog_vapp_template" "example" {
 	catalog_name  	= "Orange-Linux"
-	template_name 	= "UBUNTU_20.04"
+	template_name 	= "UBUNTU_22.04"
 }
 
 resource "cloudavenue_vm" "example" {


### PR DESCRIPTION
### Description of your changes

Update `template_name` from `UBUNTU_20.04` to `UBUNTU_22.04` in acceptance tests, as the Ubuntu 20.04 template is no longer available in the `Orange-Linux` catalog.

Fixes #1224

If you submit change in the provider code, please make sure to:

- [ ] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [ ] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

The acceptance tests `TestAccCatalogVAppTemplateDataSource` and `TestAccVMDataSource` were updated to reference the `UBUNTU_22.04` template. These tests can be run against a live CloudAvenue environment to confirm that the template is found and all attribute checks pass.