### PR TITLE
fix(acl): resolve vdc/vapp ACL subjects via admin org lookups

### DIFF
--- a/internal/provider/common/acl/acl.go
+++ b/internal/provider/common/acl/acl.go
@@ -191,20 +191,41 @@ func SharedSetToAccessControl(_ *govcd.VCDClient, org *govcd.AdminOrg, input []S
 	return output, outputModel, nil
 }
 
-func AccessControlListToSharedSet(input []*govcdtypes.AccessSetting) ([]SharedWithModel, error) {
+func AccessControlListToSharedSet(org *govcd.AdminOrg, input []*govcdtypes.AccessSetting) ([]SharedWithModel, error) {
+	if org == nil {
+		return nil, fmt.Errorf("admin organization is required to resolve ACL subjects")
+	}
+
 	var output []SharedWithModel
 
 	for _, item := range input {
+		if item == nil || item.Subject == nil {
+			return nil, fmt.Errorf("access setting subject is missing")
+		}
+		if item.ExternalSubject != nil {
+			return nil, fmt.Errorf("external subject '%s' is not supported", item.ExternalSubject.SubjectId)
+		}
+
 		o := SharedWithModel{}
 
-		switch item.Subject.Type {
-		case govcdtypes.MimeAdminUser:
+		subjectUUID := urn.ExtractUUID(item.Subject.HREF)
+		if subjectUUID == "" {
+			return nil, fmt.Errorf("cannot extract subject UUID from href '%s' for item %s", item.Subject.HREF, item.Subject.Name)
+		}
 
-			o.UserID = types.StringValue(urn.Normalize(urn.User, urn.ExtractUUID(item.Subject.HREF)).String())
-		case govcdtypes.MimeAdminGroup:
-			o.GroupID = types.StringValue(urn.Normalize(urn.Group, urn.ExtractUUID(item.Subject.HREF)).String())
-		default:
-			return nil, fmt.Errorf("unhandled type '%s' for item %s", item.Subject.Type, item.Subject.Name)
+		if _, err := org.GetUserById(subjectUUID, false); err == nil {
+			o.UserID = types.StringValue(urn.Normalize(urn.User, subjectUUID).String())
+		} else if _, err := org.GetGroupById(subjectUUID, false); err == nil {
+			o.GroupID = types.StringValue(urn.Normalize(urn.Group, subjectUUID).String())
+		} else {
+			switch item.Subject.Type {
+			case govcdtypes.MimeAdminUser:
+				o.UserID = types.StringValue(urn.Normalize(urn.User, subjectUUID).String())
+			case govcdtypes.MimeAdminGroup:
+				o.GroupID = types.StringValue(urn.Normalize(urn.Group, subjectUUID).String())
+			default:
+				return nil, fmt.Errorf("cannot resolve ACL subject '%s' (%s)", item.Subject.Name, item.Subject.HREF)
+			}
 		}
 		o.AccessLevel = types.StringValue(item.AccessLevel)
 		o.SubjectName = types.StringValue(item.Subject.Name)

--- a/internal/provider/common/acl/acl.go
+++ b/internal/provider/common/acl/acl.go
@@ -213,19 +213,32 @@ func AccessControlListToSharedSet(org *govcd.AdminOrg, input []*govcdtypes.Acces
 			return nil, fmt.Errorf("cannot extract subject UUID from href '%s' for item %s", item.Subject.HREF, item.Subject.Name)
 		}
 
-		if _, err := org.GetUserById(subjectUUID, false); err == nil {
-			o.UserID = types.StringValue(urn.Normalize(urn.User, subjectUUID).String())
-		} else if _, err := org.GetGroupById(subjectUUID, false); err == nil {
-			o.GroupID = types.StringValue(urn.Normalize(urn.Group, subjectUUID).String())
-		} else {
-			switch item.Subject.Type {
-			case govcdtypes.MimeAdminUser:
-				o.UserID = types.StringValue(urn.Normalize(urn.User, subjectUUID).String())
-			case govcdtypes.MimeAdminGroup:
-				o.GroupID = types.StringValue(urn.Normalize(urn.Group, subjectUUID).String())
-			default:
-				return nil, fmt.Errorf("cannot resolve ACL subject '%s' (%s)", item.Subject.Name, item.Subject.HREF)
+		switch item.Subject.Type {
+		case govcdtypes.MimeAdminUser:
+			if _, err := org.GetUserById(subjectUUID, false); err != nil {
+				return nil, fmt.Errorf("cannot resolve ACL subject '%s' (%s): %w", item.Subject.Name, item.Subject.HREF, err)
 			}
+			o.UserID = types.StringValue(urn.Normalize(urn.User, subjectUUID).String())
+		case govcdtypes.MimeAdminGroup:
+			if _, err := org.GetGroupById(subjectUUID, false); err != nil {
+				return nil, fmt.Errorf("cannot resolve ACL subject '%s' (%s): %w", item.Subject.Name, item.Subject.HREF, err)
+			}
+			o.GroupID = types.StringValue(urn.Normalize(urn.Group, subjectUUID).String())
+		default:
+			if _, err := org.GetUserById(subjectUUID, false); err == nil {
+				o.UserID = types.StringValue(urn.Normalize(urn.User, subjectUUID).String())
+				break
+			} else if !govcd.ContainsNotFound(err) {
+				return nil, fmt.Errorf("error retrieving ACL user %s: %w", subjectUUID, err)
+			}
+
+			if _, err := org.GetGroupById(subjectUUID, false); err == nil {
+				o.GroupID = types.StringValue(urn.Normalize(urn.Group, subjectUUID).String())
+				break
+			} else if !govcd.ContainsNotFound(err) {
+				return nil, fmt.Errorf("error retrieving ACL group %s: %w", subjectUUID, err)
+			}
+			return nil, fmt.Errorf("cannot resolve ACL subject '%s' (%s)", item.Subject.Name, item.Subject.HREF)
 		}
 		o.AccessLevel = types.StringValue(item.AccessLevel)
 		o.SubjectName = types.StringValue(item.Subject.Name)

--- a/internal/provider/vapp/acl_resource.go
+++ b/internal/provider/vapp/acl_resource.go
@@ -179,7 +179,11 @@ func (r *aclResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	if accessControl.AccessSettings != nil {
 		adminOrg, err := r.client.Vmware.GetAdminOrgByNameOrId(r.client.GetOrgName())
 		if err != nil {
-			resp.Diagnostics.AddError("Error retrieving Org", err.Error())
+			wrappedErr := fmt.Errorf("failed to resolve admin organization for current org %q: %w", r.client.GetOrgName(), err)
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("Error resolving admin organization for current org %q", r.client.GetOrgName()),
+				wrappedErr.Error(),
+			)
 			return
 		}
 
@@ -229,6 +233,7 @@ func (r *aclResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	// Update resource
 	plan, diags := r.createOrUpdateACL(ctx, plan)
+	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
 	}
@@ -324,7 +329,11 @@ func (r *aclResource) createOrUpdateACL(ctx context.Context, plan *aclResourceMo
 		// Get admin Org
 		adminOrg, err := r.client.Vmware.GetAdminOrgByNameOrId(r.client.GetOrgName())
 		if err != nil {
-			diags.AddError("Error retrieving Org", err.Error())
+			wrappedErr := fmt.Errorf("failed to resolve admin organization for current org %q: %w", r.client.GetOrgName(), err)
+			diags.AddError(
+				fmt.Sprintf("Error resolving admin organization for current org %q", r.client.GetOrgName()),
+				wrappedErr.Error(),
+			)
 			return nil, diags
 		}
 

--- a/internal/provider/vapp/acl_resource.go
+++ b/internal/provider/vapp/acl_resource.go
@@ -177,7 +177,13 @@ func (r *aclResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 
 	plan.SharedWith = types.SetNull(types.ObjectType{AttrTypes: acl.SharedWithModelAttrTypes})
 	if accessControl.AccessSettings != nil {
-		accessControlListSet, err := acl.AccessControlListToSharedSet(accessControl.AccessSettings.AccessSetting)
+		adminOrg, err := r.client.Vmware.GetAdminOrgByNameOrId(r.client.GetOrgName())
+		if err != nil {
+			resp.Diagnostics.AddError("Error retrieving Org", err.Error())
+			return
+		}
+
+		accessControlListSet, err := acl.AccessControlListToSharedSet(adminOrg, accessControl.AccessSettings.AccessSetting)
 		if err != nil {
 			resp.Diagnostics.AddError("Error converting slice AccessSetting into set", err.Error())
 			return

--- a/internal/provider/vdc/acl_resource.go
+++ b/internal/provider/vdc/acl_resource.go
@@ -170,7 +170,13 @@ func (r *aclResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 
 	plan.SharedWith = types.SetNull(types.ObjectType{AttrTypes: acl.SharedWithModelAttrTypes})
 	if controlAccessParams.AccessSettings != nil {
-		accessControlListSet, err := acl.AccessControlListToSharedSet(controlAccessParams.AccessSettings.AccessSetting)
+		adminOrg, err := r.client.Vmware.GetAdminOrgByNameOrId(r.client.GetOrgName())
+		if err != nil {
+			resp.Diagnostics.AddError("Error retrieving Org", err.Error())
+			return
+		}
+
+		accessControlListSet, err := acl.AccessControlListToSharedSet(adminOrg, controlAccessParams.AccessSettings.AccessSetting)
 		if err != nil {
 			resp.Diagnostics.AddError("Error converting slice AccessSetting into set", err.Error())
 			return

--- a/internal/provider/vdc/acl_resource.go
+++ b/internal/provider/vdc/acl_resource.go
@@ -172,7 +172,11 @@ func (r *aclResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	if controlAccessParams.AccessSettings != nil {
 		adminOrg, err := r.client.Vmware.GetAdminOrgByNameOrId(r.client.GetOrgName())
 		if err != nil {
-			resp.Diagnostics.AddError("Error retrieving Org", err.Error())
+			wrappedErr := fmt.Errorf("failed to resolve admin organization for current org %q: %w", r.client.GetOrgName(), err)
+			resp.Diagnostics.AddError(
+				fmt.Sprintf("Error resolving admin organization for current org %q", r.client.GetOrgName()),
+				wrappedErr.Error(),
+			)
 			return
 		}
 
@@ -222,6 +226,7 @@ func (r *aclResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	// Update resource
 	plan, diags := r.createOrUpdateACL(ctx, plan)
+	resp.Diagnostics.Append(diags...)
 	if diags.HasError() {
 		return
 	}
@@ -286,7 +291,11 @@ func (r *aclResource) createOrUpdateACL(ctx context.Context, plan *aclResourceMo
 		// Get admin Org
 		adminOrg, err := r.client.Vmware.GetAdminOrgByNameOrId(r.client.GetOrgName())
 		if err != nil {
-			diags.AddError("Error retrieving Org", err.Error())
+			wrappedErr := fmt.Errorf("failed to resolve admin organization for current org %q: %w", r.client.GetOrgName(), err)
+			diags.AddError(
+				fmt.Sprintf("Error resolving admin organization for current org %q", r.client.GetOrgName()),
+				wrappedErr.Error(),
+			)
 			return nil, diags
 		}
 


### PR DESCRIPTION
### Description of your changes

- fix ACL read failures by resolving shared ACL subjects through AdminOrg lookups instead of relying only on API subject type metadata
- update `cloudavenue_vdc_acl` and `cloudavenue_vapp_acl` read paths to load AdminOrg before rebuilding shared access settings
- add defensive handling for missing subjects, unsupported external subjects, and malformed subject references

Fixes #1241

### How has this code been tested

- Not run locally (not requested)
