### PR TITLE
feat(vdcg_network_routed): add MoveState to fix migration when edge gateway is connected to a VDC Group (#1231)

### DIFF
--- a/.changelog/1231.txt
+++ b/.changelog/1231.txt
@@ -1,0 +1,3 @@
+```release-note:note
+`resource/cloudavenue_network_routed` - Fixed migration guide for `cloudavenue_edgegateway_network_routed`: added Terraform >= 1.8 requirement for cross-type `moved` block support, fixed single resource example, and added `for_each` migration instructions.
+```

--- a/.changelog/1244.txt
+++ b/.changelog/1244.txt
@@ -1,3 +1,7 @@
+```release-note:feature
+`resource/cloudavenue_vdcg_network_routed` - Added `MoveState` support to enable migration from `cloudavenue_network_routed` via `moved` block. This fixes migration for users whose edge gateway is connected to a VDC Group.
+```
+
 ```release-note:note
 `resource/cloudavenue_network_routed` - Fixed migration guide for `cloudavenue_edgegateway_network_routed`: added Terraform >= 1.8 requirement for cross-type `moved` block support, fixed single resource example, and added `for_each` migration instructions.
 ```

--- a/docs/resources/network_routed.md
+++ b/docs/resources/network_routed.md
@@ -15,10 +15,6 @@ Provides a Cloud Avenue vDC routed Network. This can be used to create, modify, 
 
 ## How to migrate existing resources
 
-~> **Terraform >= 1.8 required** Cross-type resource migration via the [`moved` block](https://developer.hashicorp.com/terraform/language/modules/develop/refactoring#move-a-resource-or-module) was introduced in [Terraform 1.8.0](https://github.com/hashicorp/terraform/blob/v1.8/CHANGELOG.md#180-april-10-2024): *"Providers can now transfer the ownership of a remote object between resources of different types"*. See the [Terraform plugin framework state move documentation](https://developer.hashicorp.com/terraform/plugin/framework/resources/state-move) for details. If you are using an older version, upgrade Terraform before following this procedure.
-
-### Single resource
-
 Original configuration:
 
 ```terraform
@@ -44,11 +40,41 @@ resource "cloudavenue_network_routed" "example" {
 }
 ```
 
-Rename the resource block to `cloudavenue_edgegateway_network_routed` and add a `moved` block:
+Migrated configuration:
+
+Rename the resource to `cloudavenue_edgegateway_network_routed` and add the `moved` block to the configuration:
 
 ```hcl
 resource "cloudavenue_edgegateway_network_routed" "example" {
+  name               = "my-isolated-network"
+  edge_gateway_name  = cloudavenue_edgegateway.example.name
+
+  gateway       = "192.168.0.1"
+  prefix_length = 24
+
+  dns1       = "192.168.0.2"
+  dns2       = "192.168.0.3"
+  dns_suffix = "example.local"
+}
+
+moved {
+  from = cloudavenue_network_routed.example
+  to   = cloudavenue_edgegateway_network_routed.example
+}
+```
+
+Run `terraform plan` and `terraform apply` to migrate the resource.
+
+### Migrate to `cloudavenue_vdcg_network_routed` (Edge Gateway in VDC Group)
+
+~> If your Edge Gateway is connected to a **VDC Group**, you must migrate to [`cloudavenue_vdcg_network_routed`](https://registry.terraform.io/providers/orange-cloudavenue/cloudavenue/latest/docs/resources/vdcg_network_routed) instead of `cloudavenue_edgegateway_network_routed`.
+
+#### Single resource
+
+```hcl
+resource "cloudavenue_vdcg_network_routed" "example" {
   name            = "example"
+  vdc_group_id    = cloudavenue_vdcg.example.id
   edge_gateway_id = cloudavenue_edgegateway.example.id
 
   gateway       = "192.168.1.254"
@@ -69,35 +95,19 @@ resource "cloudavenue_edgegateway_network_routed" "example" {
 
 moved {
   from = cloudavenue_network_routed.example
-  to   = cloudavenue_edgegateway_network_routed.example
+  to   = cloudavenue_vdcg_network_routed.example
 }
 ```
 
-Run `terraform plan` and `terraform apply` to migrate the resource.
-
-Example of terraform plan output:
-
-```shell
-Terraform will perform the following actions:
-
-  # cloudavenue_network_routed.example has moved to cloudavenue_edgegateway_network_routed.example
-    resource "cloudavenue_edgegateway_network_routed" "example" {
-        id                 = "urn:vcloud:network:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        name               = "example"
-        # (10 unchanged attributes hidden)
-    }
-
-Plan: 0 to add, 0 to change, 0 to destroy.
-```
-
-### Resource with `for_each`
+#### Resource with `for_each`
 
 When using `for_each`, each instance must have its own `moved` block using the instance key:
 
 ```hcl
-resource "cloudavenue_edgegateway_network_routed" "this" {
+resource "cloudavenue_vdcg_network_routed" "this" {
   for_each        = local.networks_info
   name            = each.value.name
+  vdc_group_id    = each.value.vdc_group_id
   edge_gateway_id = each.value.edge_gateway_id
 
   gateway       = each.value.gateway
@@ -112,11 +122,28 @@ resource "cloudavenue_edgegateway_network_routed" "this" {
 
 moved {
   from = cloudavenue_network_routed.this["my-network"]
-  to   = cloudavenue_edgegateway_network_routed.this["my-network"]
+  to   = cloudavenue_vdcg_network_routed.this["my-network"]
 }
 ```
 
 Add one `moved` block per instance key. Once `terraform apply` has completed successfully, the `moved` blocks can be removed.
+
+---
+
+Example of terraform plan output:
+
+```shell
+Terraform will perform the following actions:
+
+  # cloudavenue_network_routed.example has moved to cloudavenue_edgegateway_network_routed.example
+    resource "cloudavenue_edgegateway_network_routed" "example" {
+        id                 = "urn:vcloud:network:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        name               = "rsx-example-isolated-network"
+        # (10 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+```
 
 ## Example Usage
 

--- a/docs/resources/network_routed.md
+++ b/docs/resources/network_routed.md
@@ -15,6 +15,10 @@ Provides a Cloud Avenue vDC routed Network. This can be used to create, modify, 
 
 ## How to migrate existing resources
 
+~> **Terraform >= 1.8 required** Cross-type resource migration via the [`moved` block](https://developer.hashicorp.com/terraform/language/modules/develop/refactoring#move-a-resource-or-module) was introduced in [Terraform 1.8.0](https://github.com/hashicorp/terraform/blob/v1.8/CHANGELOG.md#180-april-10-2024): *"Providers can now transfer the ownership of a remote object between resources of different types"*. See the [Terraform plugin framework state move documentation](https://developer.hashicorp.com/terraform/plugin/framework/resources/state-move) for details. If you are using an older version, upgrade Terraform before following this procedure.
+
+### Single resource
+
 Original configuration:
 
 ```terraform
@@ -40,21 +44,27 @@ resource "cloudavenue_network_routed" "example" {
 }
 ```
 
-Migrated configuration:
-
-Rename the resource to `cloudavenue_edgegateway_network_routed` and add the `moved` block to the configuration:
+Rename the resource block to `cloudavenue_edgegateway_network_routed` and add a `moved` block:
 
 ```hcl
 resource "cloudavenue_edgegateway_network_routed" "example" {
-  name               = "my-isolated-network"
-  edge_gateway_name  = cloudavenue_edgegateway.example.name
+  name            = "example"
+  edge_gateway_id = cloudavenue_edgegateway.example.id
 
-  gateway       = "192.168.0.1"
+  gateway       = "192.168.1.254"
   prefix_length = 24
 
-  dns1       = "192.168.0.2"
-  dns2       = "192.168.0.3"
-  dns_suffix = "example.local"
+  dns1 = "1.1.1.1"
+  dns2 = "8.8.8.8"
+
+  dns_suffix = "example"
+
+  static_ip_pool = [
+    {
+      start_address = "192.168.1.10"
+      end_address   = "192.168.1.20"
+    }
+  ]
 }
 
 moved {
@@ -73,12 +83,40 @@ Terraform will perform the following actions:
   # cloudavenue_network_routed.example has moved to cloudavenue_edgegateway_network_routed.example
     resource "cloudavenue_edgegateway_network_routed" "example" {
         id                 = "urn:vcloud:network:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        name               = "rsx-example-isolated-network"
+        name               = "example"
         # (10 unchanged attributes hidden)
     }
 
 Plan: 0 to add, 0 to change, 0 to destroy.
 ```
+
+### Resource with `for_each`
+
+When using `for_each`, each instance must have its own `moved` block using the instance key:
+
+```hcl
+resource "cloudavenue_edgegateway_network_routed" "this" {
+  for_each        = local.networks_info
+  name            = each.value.name
+  edge_gateway_id = each.value.edge_gateway_id
+
+  gateway       = each.value.gateway
+  prefix_length = each.value.prefix_length
+
+  dns1       = each.value.dns1
+  dns2       = each.value.dns2
+  dns_suffix = each.value.dns_suffix
+
+  static_ip_pool = each.value.static_ip_pool
+}
+
+moved {
+  from = cloudavenue_network_routed.this["my-network"]
+  to   = cloudavenue_edgegateway_network_routed.this["my-network"]
+}
+```
+
+Add one `moved` block per instance key. Once `terraform apply` has completed successfully, the `moved` blocks can be removed.
 
 ## Example Usage
 

--- a/docs/resources/vdcg_network_routed.md
+++ b/docs/resources/vdcg_network_routed.md
@@ -9,6 +9,86 @@ description: |-
 
 The `cloudavenue_vdcg_network_routed` resource allows you to manage a routed network within the VDC Group scope. If you want to manage a routed network in the vdc scope, please use the [`cloudavenue_edgegateway_network_routed`](https://registry.terraform.io/providers/orange-cloudavenue/cloudavenue/latest/docs/resources/edgegateway_network_routed) resource.
 
+## How to migrate from `cloudavenue_network_routed`
+
+~> **Terraform >= 1.8 required** Cross-type resource migration via the [`moved` block](https://developer.hashicorp.com/terraform/language/modules/develop/refactoring#move-a-resource-or-module) was introduced in [Terraform 1.8.0](https://github.com/hashicorp/terraform/blob/v1.8/CHANGELOG.md#180-april-10-2024): *"Providers can now transfer the ownership of a remote object between resources of different types"*.
+
+If you are migrating from the deprecated `cloudavenue_network_routed` resource and your Edge Gateway is connected to a **VDC Group**, use this migration path:
+
+```hcl
+resource "cloudavenue_vdcg_network_routed" "example" {
+  name            = "example"
+  vdc_group_id    = cloudavenue_vdcg.example.id
+  edge_gateway_id = cloudavenue_edgegateway.example.id
+
+  gateway       = "192.168.1.254"
+  prefix_length = 24
+
+  dns1 = "1.1.1.1"
+  dns2 = "8.8.8.8"
+
+  dns_suffix = "example"
+
+  static_ip_pool = [
+    {
+      start_address = "192.168.1.10"
+      end_address   = "192.168.1.20"
+    }
+  ]
+}
+
+moved {
+  from = cloudavenue_network_routed.example
+  to   = cloudavenue_vdcg_network_routed.example
+}
+```
+
+### Resource with `for_each`
+
+When using `for_each`, each instance must have its own `moved` block using the instance key:
+
+```hcl
+resource "cloudavenue_vdcg_network_routed" "this" {
+  for_each        = local.networks_info
+  name            = each.value.name
+  vdc_group_id    = each.value.vdc_group_id
+  edge_gateway_id = each.value.edge_gateway_id
+
+  gateway       = each.value.gateway
+  prefix_length = each.value.prefix_length
+
+  dns1       = each.value.dns1
+  dns2       = each.value.dns2
+  dns_suffix = each.value.dns_suffix
+
+  static_ip_pool = each.value.static_ip_pool
+}
+
+moved {
+  from = cloudavenue_network_routed.this["my-network"]
+  to   = cloudavenue_vdcg_network_routed.this["my-network"]
+}
+```
+
+Add one `moved` block per instance key. Once `terraform apply` has completed successfully, the `moved` blocks can be removed.
+
+Run `terraform plan` and `terraform apply` to migrate the resource.
+
+Example of terraform plan output:
+
+```shell
+Terraform will perform the following actions:
+
+  # cloudavenue_network_routed.example has moved to cloudavenue_vdcg_network_routed.example
+    resource "cloudavenue_vdcg_network_routed" "example" {
+        id                 = "urn:vcloud:network:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        name               = "example"
+        # (11 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+```
+
 ## Example Usage
 
 ```terraform

--- a/internal/provider/vdcg/network_routed_resource.go
+++ b/internal/provider/vdcg/network_routed_resource.go
@@ -30,12 +30,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
 	v1 "github.com/orange-cloudavenue/cloudavenue-sdk-go/v1"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/client"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/metrics"
 	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/common/mutex"
+	"github.com/orange-cloudavenue/terraform-provider-cloudavenue/internal/provider/network"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -43,6 +45,7 @@ var (
 	_ resource.Resource                = &NetworkRoutedResource{}
 	_ resource.ResourceWithConfigure   = &NetworkRoutedResource{}
 	_ resource.ResourceWithImportState = &NetworkRoutedResource{}
+	_ resource.ResourceWithMoveState   = &NetworkRoutedResource{}
 )
 
 // NewNetworkRoutedResource is a helper function to simplify the provider implementation.
@@ -63,6 +66,22 @@ func (r *NetworkRoutedResource) Init(_ context.Context, rm *NetworkRoutedModel) 
 	idOrName := rm.VDCGroupID.Get()
 	if idOrName == "" {
 		idOrName = rm.VDCGroupName.Get()
+	}
+
+	// Fallback: resolve VDC Group from edge gateway when VDC Group fields are empty.
+	// This happens after a MoveState migration where the deprecated
+	// cloudavenue_network_routed resource has no VDC Group fields.
+	if idOrName == "" {
+		edgeIDOrName := rm.EdgeGatewayID.Get()
+		if edgeIDOrName == "" {
+			edgeIDOrName = rm.EdgeGatewayName.Get()
+		}
+		if edgeIDOrName != "" {
+			if edgeGW, err := r.client.CAVSDK.V1.EdgeGateway.Get(edgeIDOrName); err == nil && edgeGW.OwnerName != "" {
+				idOrName = edgeGW.OwnerName
+				rm.VDCGroupName.Set(edgeGW.OwnerName)
+			}
+		}
 	}
 
 	r.vdcg, err = r.client.CAVSDK.V1.VDC().GetVDCGroup(idOrName)
@@ -105,6 +124,94 @@ func (r *NetworkRoutedResource) Configure(_ context.Context, req resource.Config
 		return
 	}
 	r.client = client
+}
+
+// MoveState implements resource.ResourceWithMoveState.
+//
+// This enables state migration from the deprecated cloudavenue_network_routed
+// resource via Terraform's `moved` block.
+//
+// VDCGroupID/VDCGroupName are left null — they are resolved during Read()
+// via Init(), which falls back to resolving the VDC Group from the edge
+// gateway's OwnerName when these fields are empty.
+//
+// Source schema: cloudavenue_network_routed (deprecated)
+// Target schema: cloudavenue_vdcg_network_routed
+func (r *NetworkRoutedResource) MoveState(_ context.Context) []resource.StateMover {
+	return []resource.StateMover{
+		{
+			SourceSchema: func() *schema.Schema {
+				ctx := context.Background()
+				schemaRequest := resource.SchemaRequest{}
+				schemaResponse := &resource.SchemaResponse{}
+
+				network.NewNetworkRoutedResource().Schema(ctx, schemaRequest, schemaResponse)
+				if schemaResponse.Diagnostics.HasError() {
+					return nil
+				}
+
+				return &schemaResponse.Schema
+			}(),
+			StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+				if req.SourceTypeName != "cloudavenue_network_routed" {
+					return
+				}
+
+				if req.SourceSchemaVersion != 0 {
+					return
+				}
+
+				if !strings.HasSuffix(req.SourceProviderAddress, "cloudavenue") {
+					return
+				}
+
+				source := &network.RoutedModel{}
+				resp.Diagnostics.Append(req.SourceState.Get(ctx, source)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				dest := &NetworkRoutedModel{
+					ID:               source.ID,
+					Name:             source.Name,
+					Description:      source.Description,
+					EdgeGatewayID:    source.EdgeGatewayID,
+					EdgeGatewayName:  source.EdgeGatewayName,
+					Gateway:          source.Gateway,
+					PrefixLength:     source.PrefixLength,
+					DNS1:             source.DNS1,
+					DNS2:             source.DNS2,
+					DNSSuffix:        source.DNSSuffix,
+					StaticIPPool:     supertypes.NewSetNestedObjectValueOfNull[NetworkRoutedModelStaticIPPool](ctx),
+					GuestVLANAllowed: supertypes.NewBoolNull(),
+					VDCGroupID:       supertypes.NewStringNull(),
+					VDCGroupName:     supertypes.NewStringNull(),
+				}
+
+				// Map StaticIPPool
+				sIPPools, d := source.StaticIPPool.Get(ctx)
+				if d.HasError() {
+					resp.Diagnostics.Append(d...)
+					return
+				}
+
+				dIPPools := []*NetworkRoutedModelStaticIPPool{}
+				for _, ipPool := range sIPPools {
+					dIPPools = append(dIPPools, &NetworkRoutedModelStaticIPPool{
+						StartAddress: ipPool.StartAddress,
+						EndAddress:   ipPool.EndAddress,
+					})
+				}
+
+				resp.Diagnostics.Append(dest.StaticIPPool.Set(ctx, dIPPools)...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+
+				resp.Diagnostics.Append(resp.TargetState.Set(ctx, &dest)...)
+			},
+		},
+	}
 }
 
 // Create creates the resource and sets the initial Terraform state.

--- a/internal/testsacc/constants_test.go
+++ b/internal/testsacc/constants_test.go
@@ -128,6 +128,9 @@ const (
 	// Additional test name constants.
 	testNameExample2 = "example_2"
 
+	// testNameMoveState is the test name for MoveState migration tests.
+	testNameMoveState = "example_move_state"
+
 	// Common attribute keys used in check functions (additional).
 	testAttrProtocol         = "protocol"
 	testAttrCriteria         = "criteria"

--- a/internal/testsacc/vdcg_network_routed_resource_test.go
+++ b/internal/testsacc/vdcg_network_routed_resource_test.go
@@ -386,6 +386,96 @@ func (r *VDCGNetworkRoutedResource) Tests(_ context.Context) map[testsacc.TestNa
 				},
 			}
 		},
+		// ! MoveState testing
+		testNameMoveState: func(_ context.Context, resourceName string) testsacc.Test {
+			return testsacc.Test{
+				CommonChecks: []resource.TestCheckFunc{},
+				// ! Create testing (old deprecated resource — must use hardcoded address since resourceName points to new type)
+				Create: testsacc.TFConfig{
+					TFConfig: testsacc.GenerateFromTemplate(resourceName, `
+					resource "cloudavenue_network_routed" "example_move_state" {
+						name             = {{ generate . "name" }}
+						description      = {{ generate . "description" }}
+						edge_gateway_id  = cloudavenue_edgegateway.example_with_vdc_group.id
+
+						gateway       = "192.168.200.1"
+						prefix_length = 24
+
+						dns1 = "1.1.1.1"
+						dns2 = "1.0.0.1"
+						dns_suffix = "example.com"
+
+						static_ip_pool = [
+						{
+							start_address = "192.168.200.10"
+							end_address   = "192.168.200.20"
+						}
+						]
+					}`),
+					Checks: []resource.TestCheckFunc{
+						resource.TestCheckResourceAttr("cloudavenue_network_routed.example_move_state", "name", testsacc.GetValueFromTemplate(resourceName, "name")),
+						resource.TestCheckResourceAttr("cloudavenue_network_routed.example_move_state", "description", testsacc.GetValueFromTemplate(resourceName, "description")),
+						resource.TestCheckResourceAttr("cloudavenue_network_routed.example_move_state", "gateway", "192.168.200.1"),
+						resource.TestCheckResourceAttr("cloudavenue_network_routed.example_move_state", "prefix_length", "24"),
+						resource.TestCheckResourceAttr("cloudavenue_network_routed.example_move_state", "dns1", "1.1.1.1"),
+						resource.TestCheckResourceAttr("cloudavenue_network_routed.example_move_state", "dns2", "1.0.0.1"),
+						resource.TestCheckResourceAttr("cloudavenue_network_routed.example_move_state", "dns_suffix", "example.com"),
+						resource.TestCheckResourceAttr("cloudavenue_network_routed.example_move_state", "static_ip_pool.#", "1"),
+						resource.TestCheckTypeSetElemNestedAttrs("cloudavenue_network_routed.example_move_state", "static_ip_pool.*", map[string]string{
+							testAttrStartAddress: "192.168.200.10",
+							testAttrEndAddress:   "192.168.200.20",
+						}),
+					},
+				},
+				// ! Updates testing (moved block to new resource type)
+				Updates: []testsacc.TFConfig{
+					{
+						TFConfig: testsacc.GenerateFromTemplate(resourceName, `
+						resource "cloudavenue_vdcg_network_routed" "example_move_state" {
+							name        = {{ get . "name" }}
+							description = {{ get . "description" }}
+							vdc_group_id    = cloudavenue_vdcg.example.id
+							edge_gateway_id = cloudavenue_edgegateway.example_with_vdc_group.id
+
+							gateway       = "192.168.200.1"
+							prefix_length = 24
+
+							dns1 = "1.1.1.1"
+							dns2 = "1.0.0.1"
+							dns_suffix = "example.com"
+
+							static_ip_pool = [
+							{
+								start_address = "192.168.200.10"
+								end_address   = "192.168.200.20"
+							}
+							]
+						}
+
+						moved {
+							from = cloudavenue_network_routed.example_move_state
+							to   = cloudavenue_vdcg_network_routed.example_move_state
+						}`),
+						Checks: []resource.TestCheckFunc{
+							resource.TestCheckResourceAttr(resourceName, "name", testsacc.GetValueFromTemplate(resourceName, "name")),
+							resource.TestCheckResourceAttr(resourceName, "description", testsacc.GetValueFromTemplate(resourceName, "description")),
+							resource.TestCheckResourceAttr(resourceName, "gateway", "192.168.200.1"),
+							resource.TestCheckResourceAttr(resourceName, "prefix_length", "24"),
+							resource.TestCheckResourceAttr(resourceName, "dns1", "1.1.1.1"),
+							resource.TestCheckResourceAttr(resourceName, "dns2", "1.0.0.1"),
+							resource.TestCheckResourceAttr(resourceName, "dns_suffix", "example.com"),
+							resource.TestCheckResourceAttr(resourceName, "static_ip_pool.#", "1"),
+							resource.TestCheckTypeSetElemNestedAttrs(resourceName, "static_ip_pool.*", map[string]string{
+								testAttrStartAddress: "192.168.200.10",
+								testAttrEndAddress:   "192.168.200.20",
+							}),
+							resource.TestCheckResourceAttrSet(resourceName, "vdc_group_id"),
+							resource.TestCheckResourceAttrSet(resourceName, "vdc_group_name"),
+						},
+					},
+				},
+			}
+		},
 	}
 }
 

--- a/templates/resources/network_routed.md.tmpl
+++ b/templates/resources/network_routed.md.tmpl
@@ -41,6 +41,71 @@ moved {
 
 Run `terraform plan` and `terraform apply` to migrate the resource.
 
+### Migrate to `cloudavenue_vdcg_network_routed` (Edge Gateway in VDC Group)
+
+~> If your Edge Gateway is connected to a **VDC Group**, you must migrate to [`cloudavenue_vdcg_network_routed`](https://registry.terraform.io/providers/orange-cloudavenue/cloudavenue/latest/docs/resources/vdcg_network_routed) instead of `cloudavenue_edgegateway_network_routed`.
+
+#### Single resource
+
+```hcl
+resource "cloudavenue_vdcg_network_routed" "example" {
+  name            = "example"
+  vdc_group_id    = cloudavenue_vdcg.example.id
+  edge_gateway_id = cloudavenue_edgegateway.example.id
+
+  gateway       = "192.168.1.254"
+  prefix_length = 24
+
+  dns1 = "1.1.1.1"
+  dns2 = "8.8.8.8"
+
+  dns_suffix = "example"
+
+  static_ip_pool = [
+    {
+      start_address = "192.168.1.10"
+      end_address   = "192.168.1.20"
+    }
+  ]
+}
+
+moved {
+  from = cloudavenue_network_routed.example
+  to   = cloudavenue_vdcg_network_routed.example
+}
+```
+
+#### Resource with `for_each`
+
+When using `for_each`, each instance must have its own `moved` block using the instance key:
+
+```hcl
+resource "cloudavenue_vdcg_network_routed" "this" {
+  for_each        = local.networks_info
+  name            = each.value.name
+  vdc_group_id    = each.value.vdc_group_id
+  edge_gateway_id = each.value.edge_gateway_id
+
+  gateway       = each.value.gateway
+  prefix_length = each.value.prefix_length
+
+  dns1       = each.value.dns1
+  dns2       = each.value.dns2
+  dns_suffix = each.value.dns_suffix
+
+  static_ip_pool = each.value.static_ip_pool
+}
+
+moved {
+  from = cloudavenue_network_routed.this["my-network"]
+  to   = cloudavenue_vdcg_network_routed.this["my-network"]
+}
+```
+
+Add one `moved` block per instance key. Once `terraform apply` has completed successfully, the `moved` blocks can be removed.
+
+---
+
 Example of terraform plan output:
 
 ```shell

--- a/templates/resources/vdcg_network_routed.md.tmpl
+++ b/templates/resources/vdcg_network_routed.md.tmpl
@@ -9,6 +9,86 @@ description: |-
 
 {{ .Description | trimspace }}
 
+## How to migrate from `cloudavenue_network_routed`
+
+~> **Terraform >= 1.8 required** Cross-type resource migration via the [`moved` block](https://developer.hashicorp.com/terraform/language/modules/develop/refactoring#move-a-resource-or-module) was introduced in [Terraform 1.8.0](https://github.com/hashicorp/terraform/blob/v1.8/CHANGELOG.md#180-april-10-2024): *"Providers can now transfer the ownership of a remote object between resources of different types"*.
+
+If you are migrating from the deprecated `cloudavenue_network_routed` resource and your Edge Gateway is connected to a **VDC Group**, use this migration path:
+
+```hcl
+resource "cloudavenue_vdcg_network_routed" "example" {
+  name            = "example"
+  vdc_group_id    = cloudavenue_vdcg.example.id
+  edge_gateway_id = cloudavenue_edgegateway.example.id
+
+  gateway       = "192.168.1.254"
+  prefix_length = 24
+
+  dns1 = "1.1.1.1"
+  dns2 = "8.8.8.8"
+
+  dns_suffix = "example"
+
+  static_ip_pool = [
+    {
+      start_address = "192.168.1.10"
+      end_address   = "192.168.1.20"
+    }
+  ]
+}
+
+moved {
+  from = cloudavenue_network_routed.example
+  to   = cloudavenue_vdcg_network_routed.example
+}
+```
+
+### Resource with `for_each`
+
+When using `for_each`, each instance must have its own `moved` block using the instance key:
+
+```hcl
+resource "cloudavenue_vdcg_network_routed" "this" {
+  for_each        = local.networks_info
+  name            = each.value.name
+  vdc_group_id    = each.value.vdc_group_id
+  edge_gateway_id = each.value.edge_gateway_id
+
+  gateway       = each.value.gateway
+  prefix_length = each.value.prefix_length
+
+  dns1       = each.value.dns1
+  dns2       = each.value.dns2
+  dns_suffix = each.value.dns_suffix
+
+  static_ip_pool = each.value.static_ip_pool
+}
+
+moved {
+  from = cloudavenue_network_routed.this["my-network"]
+  to   = cloudavenue_vdcg_network_routed.this["my-network"]
+}
+```
+
+Add one `moved` block per instance key. Once `terraform apply` has completed successfully, the `moved` blocks can be removed.
+
+Run `terraform plan` and `terraform apply` to migrate the resource.
+
+Example of terraform plan output:
+
+```shell
+Terraform will perform the following actions:
+
+  # cloudavenue_network_routed.example has moved to cloudavenue_vdcg_network_routed.example
+    resource "cloudavenue_vdcg_network_routed" "example" {
+        id                 = "urn:vcloud:network:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        name               = "example"
+        # (11 unchanged attributes hidden)
+    }
+
+Plan: 0 to add, 0 to change, 0 to destroy.
+```
+
 {{ if .HasExample -}}
 ## Example Usage
 


### PR DESCRIPTION
Fixes #1231

### Description of your changes

Adds `MoveState` support to `resource/cloudavenue_vdcg_network_routed` so users whose edge gateway is connected to a VDC Group can migrate from `cloudavenue_network_routed` using Terraform's `moved` block. Previously, the `moved` block only worked for edge gateways outside a VDC Group — this closes that gap.

Also fixes the migration guide for `cloudavenue_network_routed` → `cloudavenue_edgegateway_network_routed`:
- Added Terraform >= 1.8 requirement for cross-type `moved` blocks
- Fixed single-resource example
- Added `for_each` migration instructions

### Checklist

- [x] Write or modify examples in `examples/` directory
- [x] Write or modify acceptance tests
- [x] Run `make generate` to ensure the doc was updated properly

### How has this code been tested

Acceptance tests added in `internal/testsacc/vdcg_network_routed_resource_test.go` covering the MoveState migration path. Existing tests pass without regression.