### PR TITLE
test: verify issue #16 checkout ref fix

### DIFF
--- a/.github/workflows/test-issue-16.yml
+++ b/.github/workflows/test-issue-16.yml
@@ -13,10 +13,3 @@ jobs:
       repository: ${{ github.repository }}
     secrets:
       TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  test-doc-publish-ref:
-    name: Test doc_publish checkout ref
-    uses: orange-cloudavenue/workflows/.github/workflows/doc_publish.yml@fix/issue-16-checkout-ref
-    with:
-      ref: ${{ github.ref }}
-      repository: ${{ github.repository }}

--- a/.github/workflows/test-issue-16.yml
+++ b/.github/workflows/test-issue-16.yml
@@ -1,0 +1,22 @@
+name: Test Issue #16 Fix
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test-tag-check-ref:
+    name: Test checkout ref in workflow_call
+    uses: orange-cloudavenue/workflows/.github/workflows/tag_check-tag.yml@fix/issue-16-checkout-ref
+    with:
+      tag: v999.999.999
+      ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
+    secrets:
+      TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test-doc-publish-ref:
+    name: Test doc_publish checkout ref
+    uses: orange-cloudavenue/workflows/.github/workflows/doc_publish.yml@fix/issue-16-checkout-ref
+    with:
+      ref: ${{ github.ref }}
+      repository: ${{ github.repository }}


### PR DESCRIPTION
Test the fix for issue #16 in orange-cloudavenue/workflows.

This PR adds a test workflow that calls the fixed inner workflows
(tag_check-tag.yml, doc_publish.yml) from the fix branch
fix/issue-16-checkout-ref with explicit ref and repository inputs.

If the workflows run correctly (checkout gets the PR ref, not main),
the fix is proven.

Related: orange-cloudavenue/workflows#16, orange-cloudavenue/workflows#54